### PR TITLE
AG2 + MCP Example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 ![image info](images/A2A_banner.png)
 
+# A2A-ag2-example: AG2 (AutoGen) Agent with A2A Protocol
+
+This fork demonstrates integrating an AG2 (AutoGen) AssistantAgent with the Agent2Agent (A2A) protocol, showcasing how different agent frameworks can communicate via a standardized protocol.
+
+## Key Features
+- **AG2 Framework Integration**: Implements an AG2 AssistantAgent that communicates using the A2A protocol
+- **MCP Integration**: Utilizes Model Context Protocol (MCP) with mcp-youtube server
+
+## Quick Start
+1. Install the local mcp server ([mcp-youtube](https://glama.ai/mcp/servers/@sparfenyuk/mcp-youtube))
+    ```bash
+    uv tool install git+https://github.com/sparfenyuk/mcp-youtube
+    ```
+
+2. Start the AG2 agent server:
+   ```bash
+   cd samples/python/agents/ag2
+   uv run .
+   ```
+
+3. Start the client in a new terminal via one of the following:
+   - Command-line client: `cd samples/python && uv run hosts/cli --agent http://localhost:10003` 
+   - Web UI: Start with `cd demo/ui && uv run main.py`, open web ui, then add the agent at localhost:10003
+
+For complete instructions, see the [AG2 agent README](/samples/python/agents/ag2/README.md) or any other relevant README.md throughout the samples.
+
+---
+
 **_An open protocol enabling communication and interoperability between opaque agentic applications._**
 
 <!-- TOC -->

--- a/README.md
+++ b/README.md
@@ -1,30 +1,3 @@
-# A2A-ag2-example: AG2 (AutoGen) Agent with A2A Protocol
-
-This fork demonstrates integrating an AG2 (AutoGen) AssistantAgent with the Agent2Agent (A2A) protocol, showcasing how different agent frameworks can communicate via a standardized protocol.
-
-## Key Features
-- **AG2 Framework Integration**: Implements an AG2 AssistantAgent that communicates using the A2A protocol
-- **MCP Integration**: Utilizes Model Context Protocol (MCP) with mcp-youtube server
-
-## Quick Start
-1. Install the local mcp server ([mcp-youtube](https://glama.ai/mcp/servers/@sparfenyuk/mcp-youtube))
-    ```bash
-    uv tool install git+https://github.com/sparfenyuk/mcp-youtube
-    ```
-
-2. Start the AG2 agent server:
-   ```bash
-   cd samples/python/agents/ag2
-   uv run .
-   ```
-
-3. Start the client in a new terminal via one of the following:
-   - Command-line client: `cd samples/python && uv run hosts/cli --agent http://localhost:10003` 
-   - Web UI: Start with `cd demo/ui && uv run main.py`, open web ui, then add the agent at localhost:10003
-
-For complete instructions, see the [AG2 agent README](/samples/python/agents/ag2/README.md) or any other relevant README.md throughout the samples.
-
----
 ![image info](images/A2A_banner.png)
 
 **_An open protocol enabling communication and interoperability between opaque agentic applications._**
@@ -83,6 +56,7 @@ The Agent2Agent (A2A) protocol facilitates communication between independent AI 
     * [CrewAI](/samples/python/agents/crewai/README.md)
     * [LangGraph](/samples/python/agents/langgraph/README.md)
     * [Genkit](/samples/js/src/agents/README.md)
+    * [Autogen (AG2) + MCP](/samples/python/agents/ag2/README.md)
 * 📑 Review key topics to understand protocol details 
     * [A2A and MCP](https://google.github.io/A2A/#/topics/a2a_and_mcp.md)
     * [Agent Discovery](https://google.github.io/A2A/#/topics/agent_discovery.md)

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ The Agent2Agent (A2A) protocol facilitates communication between independent AI 
 
 ### **Contributing**
 
-We welcome contributions! Please see our [contributing guide](CONTRIBUTING.md) to get started.\
-Have questions? Join our community in [GitHub discussions](https://github.com/google/A2A/discussions/).\
-Help with protocol improvement feedback, in [GitHub issues](https://github.com/google/A2A/issues).\
-Want to send private feedback? use this [Google form](https://docs.google.com/forms/d/e/1FAIpQLScS23OMSKnVFmYeqS2dP7dxY3eTyT7lmtGLUa8OJZfP4RTijQ/viewform)
+We highly value community contributions and appreciate your interest in A2A Protocol! Here's how you can get involved:
+* Get Started? Please see our [contributing guide](CONTRIBUTING.md) to get started.
+* Have questions? Join our community in [GitHub discussions](https://github.com/google/A2A/discussions).
+* Want to help with protocol improvement feedback?  Dive into [GitHub issues](https://github.com/google/A2A/issues).
+* Private Feedback? Please use this [Google form](https://docs.google.com/forms/d/e/1FAIpQLScS23OMSKnVFmYeqS2dP7dxY3eTyT7lmtGLUa8OJZfP4RTijQ/viewform)
 
 ### **What's next**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![image info](images/A2A_banner.png)
-
 # A2A-ag2-example: AG2 (AutoGen) Agent with A2A Protocol
 
 This fork demonstrates integrating an AG2 (AutoGen) AssistantAgent with the Agent2Agent (A2A) protocol, showcasing how different agent frameworks can communicate via a standardized protocol.
@@ -27,6 +25,7 @@ This fork demonstrates integrating an AG2 (AutoGen) AssistantAgent with the Agen
 For complete instructions, see the [AG2 agent README](/samples/python/agents/ag2/README.md) or any other relevant README.md throughout the samples.
 
 ---
+![image info](images/A2A_banner.png)
 
 **_An open protocol enabling communication and interoperability between opaque agentic applications._**
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ The Agent2Agent (A2A) protocol facilitates communication between independent AI 
     * [Multi-Agent Web App](/demo/README.md)
     * CLI ([Python](/samples/python/hosts/cli/README.md), [JS](/samples/js/README.md))
 * 🤖 Use our [sample agents](/samples/python/agents/README.md) to see how to bring A2A to agent frameworks
-    * [Agent Developer Kit (ADK)](/samples/python/agents/google_adk/README.md)
+    * [Agent Development Kit (ADK)](/samples/python/agents/google_adk/README.md)
     * [CrewAI](/samples/python/agents/crewai/README.md)
     * [LangGraph](/samples/python/agents/langgraph/README.md)
     * [Genkit](/samples/js/src/agents/README.md)
     * [Autogen (AG2) + MCP](/samples/python/agents/ag2/README.md)
+    * [Semantic Kernel](/samples/python/agents/semantickernel/README.md)
 * 📑 Review key topics to understand protocol details 
     * [A2A and MCP](https://google.github.io/A2A/#/topics/a2a_and_mcp.md)
     * [Agent Discovery](https://google.github.io/A2A/#/topics/agent_discovery.md)

--- a/demo/ui/components/form_render.py
+++ b/demo/ui/components/form_render.py
@@ -209,7 +209,7 @@ def input_field(
     me.input(
       key=f"{id}_{key}",
       label=element.label,
-      value=element.value,
+      value=value,
       appearance="outline",
       color="warn" if key in form.errors else "primary",
       style=me.Style(width=width),

--- a/demo/ui/service/server/adk_host_manager.py
+++ b/demo/ui/service/server/adk_host_manager.py
@@ -194,7 +194,8 @@ class ADKHostManager(ApplicationManager):
         self._tasks[i] = task
         return
 
-  def task_callback(self, task: TaskCallbackArg):
+  def task_callback(self, task: TaskCallbackArg, agent_card: AgentCard):
+    self.emit_event(task, agent_card)
     if isinstance(task, TaskStatusUpdateEvent):
       current_task = self.add_or_get_task(task)
       current_task.status = task.status
@@ -219,6 +220,49 @@ class ADKHostManager(ApplicationManager):
       self.insert_id_trace(task.status.message)
       self.update_task(task)
       return task
+
+  def emit_event(self, task: TaskCallbackArg, agent_card: AgentCard):
+    content = None
+    conversation_id = get_conversation_id(task)
+    metadata = {'conversation_id': conversation_id} if conversation_id else None
+    if isinstance(task, TaskStatusUpdateEvent):
+      if task.status.message:
+        content = task.status.message
+      else:
+        content = Message(
+          parts=[TextPart(text=str(task.status.state))],
+          role="agent",
+          metadata=metadata,
+        )
+    elif isinstance(task, TaskArtifactUpdateEvent):
+      content = Message(
+          parts=task.artifact.parts,
+          role="agent",
+          metadata=metadata,
+      )
+    elif task.status and task.status.message:
+      content = task.status.message
+    elif task.artifacts:
+      parts = []
+      for a in task.artifacts:
+        parts.extend(a.parts)
+      content = Message(
+          parts=parts,
+          role="agent",
+          metadata=metadata,
+      )
+    else:
+      content = Message(
+          parts=[TextPart(text=str(task.status.state))],
+          role="agent",
+          metadata=metadata,
+      )
+    self.add_event(Event(
+          id=str(uuid.uuid4()),
+          actor=agent_card.name,
+          content=content,
+          timestamp=datetime.datetime.utcnow().timestamp(),
+    ))
 
   def attach_message_to_task(self, message: Message | None, task_id: str):
     if message and message.metadata and 'message_id' in message.metadata:
@@ -393,8 +437,10 @@ class ADKHostManager(ApplicationManager):
         ))
       elif part.file_data:
         parts.append(FilePart(
-            uri=part.file_data.file_uri,
-            mimeType=part.file_data.mime_type
+            file=FileContent(
+                uri=part.file_data.file_uri,
+                mimeType=part.file_data.mime_type
+            )
         ))
       # These aren't managed by the A2A message structure, these are internal
       # details of ADK, we will simply flatten these to json representations.
@@ -407,38 +453,7 @@ class ADKHostManager(ApplicationManager):
       elif part.function_call:
         parts.append(DataPart(data=part.function_call.model_dump()))
       elif part.function_response:
-        # Unnest response
-        try:
-          for p in part.function_response.response['result']:
-            if isinstance(p, str):
-              parts.append(TextPart(text=p))
-            elif isinstance(p, dict):
-              if 'type' in p and p['type'] == 'file':
-                parts.append(FilePart(**p))
-              else:
-                parts.append(DataPart(data=p))
-            elif isinstance(p, DataPart):
-              # If there is an artifact in the response, fetch it and add to parts.
-              if('artifact-file-id' in p.data):
-                file_part = self._artifact_service.load_artifact(user_id=self.user_id,
-                                                              session_id=conversation_id,
-                                                              app_name=self.app_name,
-                                                              filename = p.data['artifact-file-id'])
-                file_data = file_part.inline_data
-                base64_data = base64.b64encode(file_data.data).decode('utf-8')
-                parts.append(FilePart(
-                  file=FileContent(
-                      bytes=base64_data, mimeType=file_data.mime_type, name='artifact_file'
-                  )
-                ))
-              else:
-                parts.append(DataPart(data=p.data))
-            else:
-              # Not sure what this is, treat it like a json string.
-              parts.append(TextPart(text=json.dumps(p)))
-        except Exception as e:
-          print("Couldn't convert to messages:", e)
-          parts.append(DataPart(data=part.function_response.model_dump()))
+        parts.extend(self._handle_function_response(part, conversation_id))
       else:
         raise ValueError("Unexpected content, unknown type")
     return Message(
@@ -446,6 +461,39 @@ class ADKHostManager(ApplicationManager):
         parts=parts,
         metadata={'conversation_id': conversation_id},
     )
+
+  def _handle_function_response(self, part: types.Part, conversation_id: str) -> list[Part]:
+    parts = []
+    try:
+      for p in part.function_response.response['result']:
+        if isinstance(p, str):
+          parts.append(TextPart(text=p))
+        elif isinstance(p, dict):
+          if 'type' in p and p['type'] == 'file':
+            parts.append(FilePart(**p))
+          else:
+            parts.append(DataPart(data=p))
+        elif isinstance(p, DataPart):
+          if 'artifact-file-id' in p.data:
+            file_part = self._artifact_service.load_artifact(user_id=self.user_id,
+                                                          session_id=conversation_id,
+                                                          app_name=self.app_name,
+                                                          filename = p.data['artifact-file-id'])
+            file_data = file_part.inline_data
+            base64_data = base64.b64encode(file_data.data).decode('utf-8')
+            parts.append(FilePart(
+              file=FileContent(
+                  bytes=base64_data, mimeType=file_data.mime_type, name='artifact_file'
+              )
+            ))
+          else:
+            parts.append(DataPart(data=p.data))
+        else:
+          parts.append(TextPart(text=json.dumps(p)))
+    except Exception as e:
+      print("Couldn't convert to messages:", e)
+      parts.append(DataPart(data=part.function_response.model_dump()))
+    return parts
 
 def get_message_id(m: Message | None) -> str  | None:
   if not m or not m.metadata or 'message_id' not in m.metadata:
@@ -456,6 +504,20 @@ def get_last_message_id(m: Message | None) -> str | None:
   if not m or not m.metadata or 'last_message_id' not in m.metadata:
     return None
   return m.metadata['last_message_id']
+
+def get_conversation_id(
+    t: (Task |
+        TaskStatusUpdateEvent |
+        TaskArtifactUpdateEvent |
+        Message |
+        None)
+) -> str | None:
+  if (t and
+      hasattr(t, 'metadata') and
+      t.metadata and
+      'conversation_id' in t.metadata):
+    return t.metadata['conversation_id']
+  return None
 
 def task_still_open(task: Task | None) -> bool:
   if not task:

--- a/demo/ui/service/types.py
+++ b/demo/ui/service/types.py
@@ -1,7 +1,6 @@
 from typing import Union, Any
 from pydantic import BaseModel, Field, TypeAdapter
 from typing import Literal, List, Annotated, Tuple
-from datetime import datetime
 from pydantic import model_validator, ConfigDict, field_serializer
 from uuid import uuid4
 from enum import Enum

--- a/demo/ui/state/host_agent_service.py
+++ b/demo/ui/state/host_agent_service.py
@@ -176,6 +176,7 @@ def convert_event_to_state(event: Event) -> StateEvent:
       conversation_id=extract_message_conversation(event.content),
       actor=event.actor,
       role=event.content.role,
+      id=event.id,
       content=extract_content(event.content.parts),
   )
 
@@ -232,4 +233,3 @@ def extract_conversation_id(task: Task) -> str:
     if a.metadata and 'conversation_id' in a.metadata:
       return a.metadata['conversation_id']
   return ""
-

--- a/demo/ui/tests/test_adk_host_manager.py
+++ b/demo/ui/tests/test_adk_host_manager.py
@@ -1,0 +1,162 @@
+import unittest
+from typing import List, Any
+from service.server.adk_host_manager import ADKHostManager
+from google.genai import types
+from common.types import TextPart, FilePart, DataPart
+
+
+class ADKHostManagerTest(unittest.TestCase):
+  """Tests for ADKHostManager class.
+
+  This test suite verifies the conversion of ADK content to message format,
+  handling various content types including text, files, data, and function responses.
+  """
+
+  def setUp(self) -> None:
+    """Set up test fixtures."""
+    self.manager = ADKHostManager()
+    self.conversation_id = "test_conversation"
+
+  def test_adk_content_to_message_text(self) -> None:
+    """Test converting ADK content with text part to message."""
+    part = types.Part()
+    part.text = "Hello"
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1, "Message should have exactly one part")
+    self.assertIsInstance(message.parts[0], TextPart, "Part should be a TextPart")
+    self.assertEqual(message.parts[0].text, "Hello", "Text content should match")
+    self.assertEqual(message.role, "user", "Role should be preserved")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id,
+                    "Conversation ID should be preserved")
+
+  def test_adk_content_to_message_file(self):
+    """Test converting ADK content with file part to message."""
+    part = types.Part()
+    part.file_data = types.FileData(file_uri="gs://test-bucket/test.txt", mime_type="text/plain")
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], FilePart)
+    self.assertEqual(message.parts[0].type, "file")
+    self.assertEqual(message.parts[0].file.uri, "gs://test-bucket/test.txt")
+    self.assertEqual(message.parts[0].file.mimeType, "text/plain")
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_data(self):
+    """Test converting ADK content with data part to message."""
+    part = types.Part()
+    part.text = '{"key": "value"}'
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], DataPart)
+    self.assertEqual(message.parts[0].data, {"key": "value"})
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_function_response(self):
+    """Test converting ADK content with function response to message."""
+    part = types.Part()
+    part.function_response = types.FunctionResponse(
+        name="test_function",
+        response={"result": [{"type": "text", "text": "Hello"}]}
+    )
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], DataPart)
+    self.assertEqual(message.parts[0].data, {"type": "text", "text": "Hello"})
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_function_response_error(self):
+    """Test error handling when converting function response to message."""
+    part = types.Part()
+    part.function_response = types.FunctionResponse(
+        name="test_function",
+        response={"result": None}
+    )
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], DataPart)
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_empty_parts(self):
+    """Test converting ADK content with empty parts to message."""
+    content = types.Content(parts=[], role="user")
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 0)
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_unknown_type(self):
+    """Test handling unknown content type in ADK content."""
+    part = types.Part()
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    with self.assertRaisesRegex(ValueError, "Unexpected content, unknown type"):
+      self.manager.adk_content_to_message(content, self.conversation_id)
+
+  def test_adk_content_to_message_multiple_files(self) -> None:
+    """Test converting ADK content with multiple file parts to message."""
+    file1 = types.Part()
+    file1.file_data = types.FileData(file_uri="gs://test-bucket/file1.txt", mime_type="text/plain")
+    
+    file2 = types.Part()
+    file2.file_data = types.FileData(file_uri="gs://test-bucket/file2.jpg", mime_type="image/jpeg")
+    
+    content = types.Content(
+        parts=[file1, file2],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 2, "Message should have two parts")
+    self.assertIsInstance(message.parts[0], FilePart, "First part should be a FilePart")
+    self.assertIsInstance(message.parts[1], FilePart, "Second part should be a FilePart")
+    self.assertEqual(message.parts[0].file.uri, "gs://test-bucket/file1.txt")
+    self.assertEqual(message.parts[1].file.uri, "gs://test-bucket/file2.jpg")
+
+  def test_adk_content_to_message_mixed_content(self) -> None:
+    """Test converting ADK content with mixed content types to message."""
+    text_part = types.Part()
+    text_part.text = "Hello"
+    
+    file_part = types.Part()
+    file_part.file_data = types.FileData(file_uri="gs://test-bucket/test.txt", mime_type="text/plain")
+    
+    data_part = types.Part()
+    data_part.text = '{"key": "value"}'
+    
+    content = types.Content(
+        parts=[text_part, file_part, data_part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 3, "Message should have three parts")
+    self.assertIsInstance(message.parts[0], TextPart, "First part should be TextPart")
+    self.assertIsInstance(message.parts[1], FilePart, "Second part should be FilePart")
+    self.assertIsInstance(message.parts[2], DataPart, "Third part should be DataPart")
+
+if __name__ == "__main__":
+  unittest.main() 

--- a/samples/js/README.md
+++ b/samples/js/README.md
@@ -11,6 +11,15 @@ The provided samples are built using [Genkit](https://genkit.dev/) using the Gem
 
 First, follow the instructions in the agent's README file, then run `npx tsx ./cli.ts` to start up a command-line client to talk to the agents. Example:
 
+1. Navigate to the samples/js directory:
+    ```bash
+    cd samples/js
+    ```
+2. Run npm install:
+    ```bash
+    npm install
+    ```
+3. Run an agent:
 ```bash
 export GEMINI_API_KEY=<your_api_key>
 npm run agents:coder

--- a/samples/js/src/agents/README.md
+++ b/samples/js/src/agents/README.md
@@ -1,7 +1,7 @@
 ## Genkit - Sample Agents
 
-* [**Movie Info Agent**](/samples/js/src/movie-agent/README.md)  
+* [**Movie Info Agent**](/samples/js/src/agents/movie-agent/README.md) 
 This agent uses the TMDB API to answer questions about movies
 
-* [**Coder Agent**](/samples/js/src/coder/README.md)  
+* [**Coder Agent**](/samples/js/src/agents/coder/README.md)  
 This is a simple code-writing agent that emits full code files as artifacts.

--- a/samples/js/src/agents/coder/index.ts
+++ b/samples/js/src/agents/coder/index.ts
@@ -9,6 +9,11 @@ import * as schema from "../../schema.js"; // Import schema for types
 import { ai } from "./genkit.js";
 import { CodeMessage } from "./code-format.js"; // CodeMessageSchema might not be needed here
 
+if (!process.env.GEMINI_API_KEY) {  
+  console.error("GEMINI_API_KEY environment variable not set.")
+  process.exit(1);
+}
+
 async function* coderAgent({
   task,
   history, // Extract history from context

--- a/samples/js/src/agents/movie-agent/index.ts
+++ b/samples/js/src/agents/movie-agent/index.ts
@@ -9,6 +9,11 @@ import { MessageData } from "genkit";
 import { ai } from "./genkit.js";
 import { searchMovies, searchPeople } from "./tools.js";
 
+if (!process.env.GEMINI_API_KEY || !process.env.TMDB_API_KEY) {  
+  console.error("GEMINI_API_KEY and TMDB_API_KEY environment variables are required")
+  process.exit(1);
+}
+
 // Load the prompt defined in movie_agent.prompt
 const movieAgentPrompt = ai.prompt("movie_agent");
 

--- a/samples/js/src/client/README.md
+++ b/samples/js/src/client/README.md
@@ -28,7 +28,7 @@ async function run() {
     const taskId = uuidv4();
     const sendParams: TaskSendParams = {
       id: taskId,
-      message: { role: "user", parts: [{ text: "Hello, agent!" }] },
+      message: { role: "user", parts: [{ text: "Hello, agent!", type: "text" }] },
     };
     // Method now returns Task | null directly
     const taskResult: Task | null = await client.sendTask(sendParams);
@@ -67,7 +67,7 @@ async function streamTask() {
     // Construct just the params
     const streamParams: TaskSendParams = {
       id: streamingTaskId,
-      message: { role: "user", parts: [{ text: "Stream me some updates!" }] },
+      message: { role: "user", parts: [{ text: "Stream me some updates!", type: "text" }] },
     };
     // Pass only params to the client method
     const stream = client.sendTaskSubscribe(streamParams);

--- a/samples/js/src/schema.ts
+++ b/samples/js/src/schema.ts
@@ -310,7 +310,7 @@ export type FileContent = FileContentBytes | FileContentUri;
  * Represents a part of a message containing text content.
  */
 export interface TextPart {
-  type?: "text";
+  type: "text";
 
   /**
    * The text content.
@@ -330,7 +330,7 @@ export interface FilePart {
   /**
    * Type identifier for this part.
    */
-  type?: "file";
+  type: "file";
 
   /**
    * The file content, provided either inline or via URI.
@@ -350,7 +350,7 @@ export interface DataPart {
   /**
    * Type identifier for this part.
    */
-  type?: "data";
+  type: "data";
 
   /**
    * The structured data content as a JSON object.

--- a/samples/python/.gitignore
+++ b/samples/python/.gitignore
@@ -11,3 +11,4 @@ wheels/
 
 .DS_Store
 *.cache
+.env

--- a/samples/python/.gitignore
+++ b/samples/python/.gitignore
@@ -10,3 +10,4 @@ wheels/
 .venv
 
 .DS_Store
+*.cache

--- a/samples/python/.vscode/launch.json
+++ b/samples/python/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Semantic Kernel Agent",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/agents/semantickernel/__main__.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+            },
+            "args": [
+                "--host", "localhost",
+                "--port", "10000"
+            ]
+        }
+    ]
+}

--- a/samples/python/agents/ag2/README.md
+++ b/samples/python/agents/ag2/README.md
@@ -62,7 +62,7 @@ sequenceDiagram
    cd samples/python/agents/ag2
    ```
 
-3. Create an environment file with your API keys:
+3. Create an environment file with your API keys (uses openai gpt-4o):
 
    ```bash
    echo "OPENAI_API_KEY=your_api_key_here" > .env
@@ -86,7 +86,7 @@ sequenceDiagram
    uv run hosts/cli
    ```
    
-   b) Use the demo web UI:
+   b) Use the demo web UI (uses google gemini-2.0-flash-001):
    ```bash
    cd demo/ui
    echo "GOOGLE_API_KEY=your_api_key_here" > .env
@@ -140,7 +140,7 @@ Content-Type: application/json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "tasks/sendSubscribe",  // Note: Only streaming is supported
+  "method": "tasks/sendSubscribe",
   "params": {
     "id": "mcp-task-01",
     "sessionId": "user-session-123",

--- a/samples/python/agents/ag2/README.md
+++ b/samples/python/agents/ag2/README.md
@@ -1,0 +1,179 @@
+# AG2 MCP Agent with A2A Protocol
+
+This sample demonstrates an MCP-enabled agent built with [AG2](https://github.com/ag2ai/ag2) that is exposed through the A2A protocol. It showcases how different agent frameworks (LangGraph, CrewAI, and now AG2) can communicate using A2A as a lingua franca.
+
+## How It Works
+
+This agent uses AG2's AssistantAgent with MCP (Model Context Protocol) integration to access various tools and capabilities. The A2A protocol enables standardized interaction with the agent, allowing clients to discover and send requests to agents with tools exposed via MCP for complex tasks.
+
+```mermaid
+sequenceDiagram
+    participant Client as A2A Client
+    participant Server as A2A Server
+    participant Agent as AG2 (LLM + MCP Client)
+    participant MCP as MCP Server
+    participant Tools as MCP Tool Implementations
+
+    Client->>Server: Send task with query
+    Server->>Agent: Forward query to AG2 agent
+    Note over Server,Agent: Real-time status updates (streaming)
+    
+    Agent->>MCP: Request available tools
+    MCP->>Agent: Return tool definitions
+    
+    Agent->>Agent: LLM decides to use tool
+    Agent->>MCP: Send tool execution request
+    MCP->>Tools: Call tool
+    Tools->>MCP: Return tool results
+    MCP->>Agent: Return tool results
+    
+    Agent->>Agent: LLM processes tool results
+    Agent->>Server: Return completed response
+    Server->>Client: Respond with task results
+```
+
+## Key Features
+
+- **Tool Access**: Leverage various MCP tools for complex tasks
+- **Web Browsing**: Access to web browsing capabilities
+- **Code Execution**: Run Python code for data analysis tasks
+- **Image Generation**: Create images from text descriptions
+- **Real-time Streaming**: Get status updates during processing
+- **Cross-Framework Communication**: Demonstrates A2A's ability to connect different agent frameworks
+
+## Prerequisites
+
+- Python 3.12 or higher
+- UV package manager
+- OpenAI API Key (for default configuration)
+- MCP YouTube server (see installation step below)
+
+## Setup & Running
+
+1. Install the MCP YouTube server:
+
+   ```bash
+   uv tool install git+https://github.com/sparfenyuk/mcp-youtube
+   ```
+
+2. Navigate to the samples directory:
+
+   ```bash
+   cd samples/python/agents/ag2
+   ```
+
+3. Create an environment file with your API keys:
+
+   ```bash
+   echo "OPENAI_API_KEY=your_api_key_here" > .env
+   ```
+
+4. Run the agent:
+
+   ```bash
+   # Basic run on default port 10003
+   uv run .
+
+   # On custom host/port
+   uv run . --host 0.0.0.0 --port 8080
+   ```
+
+5. In a new terminal, start an A2AClient interface to interact with the remote (ag2) agent using one of these methods:
+
+   a) Run the CLI client (from the samples/python directory):
+   ```bash
+   cd samples/python
+   uv run hosts/cli
+   ```
+   
+   b) Use the demo web UI:
+   ```bash
+   cd demo/ui
+   echo "GOOGLE_API_KEY=your_api_key_here" > .env
+   uv run main.py
+   ```
+   
+   Then navigate to the web UI (typically http://localhost:12000):
+   - Click the 'Agents' tab
+   - Add the Remote Agent
+   - Enter the Agent URL: localhost:10003 (or whatever custom host/port)
+   - Click the 'Home' tab (Conversations)
+   - Create and start a conversation to test the interaction (+)
+
+## Example Usage
+
+The MCP YouTube server enables the agent to download closed captions for YouTube videos (note: does not work for YouTube Shorts). Here's an example prompt you can try:
+
+```
+Summarize this video: https://www.youtube.com/watch?v=kQmXtrmQ5Zg (Building Agents with Model Context Protocol - Full Workshop with Mahesh Murag of Anthropic)
+```
+
+## Technical Implementation
+
+- **AG2 MCP Integration**: Integrates with MCP toolkit for tool access
+- **Streaming Support**: Provides updates during task processing
+- **A2A Protocol Integration**: Full compliance with A2A specifications
+
+
+## Behind the Scenes: A2A Communication
+
+This demo provides two different interfaces to interact with the AG2 agent, both using the A2A protocol:
+
+### CLI Client (Direct Interaction)
+When using the CLI client, you interact directly with a simple A2A client that sends requests to the AG2 agent:
+```
+User → CLI (A2AClient) → AG2 Agent
+```
+
+### Web UI (Host Agent Delegation)
+When using the web UI, you interact with a Google ADK host agent, which acts as an A2A client to delegate tasks:
+```
+User → Web UI → ADK Host Agent (A2A Client) → AG2 Agent
+```
+
+In both cases, the underlying A2A protocol communication looks like this:
+
+```
+POST http://localhost:10003
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tasks/sendSubscribe",  // Note: Only streaming is supported
+  "params": {
+    "id": "mcp-task-01",
+    "sessionId": "user-session-123",
+    "acceptedOutputModes": [
+      "text"
+    ],
+    "message": {
+      "role": "user",
+      "parts": [
+        {
+          "type": "text",
+          "text": "Summarize this video: https://www.youtube.com/watch?v=kQmXtrmQ5Zg"
+        }
+      ]
+    }
+  }
+}
+```
+
+This standardized communication format is what enables different agent frameworks to interoperate seamlessly, regardless of whether they're communicating directly or through an orchestrating host agent.
+
+If you want to test the API directly via curl:
+
+```bash
+curl -X POST http://localhost:10003 \
+-H "Content-Type: application/json" \
+-d '{"jsonrpc": "2.0", "id": 1, "method": "tasks/sendSubscribe", "params": {"id": "mcp-task-01", "sessionId": "user-session-123", "acceptedOutputModes": ["text"], "message": {"role": "user", "parts": [{"type": "text", "text": "Summarize this video: https://www.youtube.com/watch?v=kQmXtrmQ5Zg"}]}}}'
+```
+
+Note: This agent only supports the async streaming endpoint (`tasks/sendSubscribe`). The synchronous endpoint (`tasks/send`) is not implemented.
+
+## Learn More
+
+- [A2A Protocol Documentation](https://google.github.io/A2A/#/documentation)
+- [AG2 Documentation](https://docs.ag2.ai/)
+- [MCP Documentation](https://modelcontextprotocol.io/introduction)

--- a/samples/python/agents/ag2/__init__.py
+++ b/samples/python/agents/ag2/__init__.py
@@ -1,0 +1,1 @@
+# AG2 WebSurfer Agent for A2A Protocol

--- a/samples/python/agents/ag2/__init__.py
+++ b/samples/python/agents/ag2/__init__.py
@@ -1,1 +1,1 @@
-# AG2 WebSurfer Agent for A2A Protocol
+# AG2 MCP Youtube Agent for A2A Protocol

--- a/samples/python/agents/ag2/__main__.py
+++ b/samples/python/agents/ag2/__main__.py
@@ -1,0 +1,67 @@
+from common.server import A2AServer
+from common.types import AgentCard, AgentCapabilities, AgentSkill, MissingAPIKeyError
+from agents.ag2.task_manager import AgentTaskManager
+from agents.ag2.agent import YoutubeMCPAgent
+import click
+import os
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@click.command()
+@click.option("--host", "host", default="localhost")
+@click.option("--port", "port", default=10003)
+def main(host, port):
+    """Starts the AG2 MCP Agent server."""
+    try:
+        if not os.getenv("OPENAI_API_KEY"):
+            raise MissingAPIKeyError("OPENAI_API_KEY environment variable not set.")
+
+        capabilities = AgentCapabilities(streaming=True)
+        skills = [
+            AgentSkill(
+                id="download_closed_captions",
+                name="Download YouTube Closed Captions",
+                description="Retrieve closed captions/transcripts from YouTube videos",
+                tags=["youtube", "captions", "transcription", "video"],
+                examples=[
+                    "Extract the transcript from this YouTube video: https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                    "Download the captions for this YouTube tutorial"
+                ]
+            )
+        ]
+        
+        agent_card = AgentCard(
+            name="YouTube Captions Agent",
+            description="AI agent that can extract closed captions and transcripts from YouTube videos. This agent provides raw transcription data that can be used for further processing.",
+            url=f"http://{host}:{port}/",
+            version="1.0.0",
+            defaultInputModes=YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES,
+            defaultOutputModes=YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES,
+            capabilities=capabilities,
+            skills=skills,
+        )
+
+        server = A2AServer(
+            agent_card=agent_card,
+            task_manager=AgentTaskManager(agent=YoutubeMCPAgent()),
+            host=host,
+            port=port,
+        )
+
+        logger.info(f"Starting AG2 MCP agent on {host}:{port}")
+        server.start()
+    except MissingAPIKeyError as e:
+        logger.error(f"Error: {e}")
+        exit(1)
+    except Exception as e:
+        logger.error(f"An error occurred during server startup: {e}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/agents/ag2/__main__.py
+++ b/samples/python/agents/ag2/__main__.py
@@ -34,7 +34,7 @@ def main(host, port):
                 ]
             )
         ]
-        
+
         agent_card = AgentCard(
             name="YouTube Captions Agent",
             description="AI agent that can extract closed captions and transcripts from YouTube videos. This agent provides raw transcription data that can be used for further processing.",
@@ -53,7 +53,7 @@ def main(host, port):
             port=port,
         )
 
-        logger.info(f"Starting AG2 MCP agent on {host}:{port}")
+        logger.info(f"Starting AG2 Youtube MCP agent on {host}:{port}")
         server.start()
     except MissingAPIKeyError as e:
         logger.error(f"Error: {e}")

--- a/samples/python/agents/ag2/agent.py
+++ b/samples/python/agents/ag2/agent.py
@@ -1,9 +1,10 @@
-import asyncio
 import logging
 import os
 import traceback
+import json
 from dotenv import load_dotenv
-from typing import AsyncIterable, Dict, Any
+from typing import AsyncIterable, Any, Literal
+from pydantic import BaseModel
 
 from autogen import AssistantAgent, LLMConfig
 from autogen.mcp import create_toolkit
@@ -13,31 +14,61 @@ from mcp.client.stdio import stdio_client
 
 logger = logging.getLogger(__name__)
 
+class ResponseModel(BaseModel):
+    """Response model for the YouTube MCP agent."""
+    text_reply: str
+    closed_captions: str | None
+    status: Literal["TERMINATE", ""]
+    
+    def format(self) -> str:
+        """Format the response as a string."""
+        if self.closed_captions is None:
+            return self.text_reply
+        else:
+            return f"{self.text_reply}\n\nClosed Captions:\n{self.closed_captions}"
+
+
 def get_api_key() -> str:
     """Helper method to handle API Key."""
     load_dotenv()
     return os.getenv("OPENAI_API_KEY")
 
 class YoutubeMCPAgent:
-    """A2A-compatible wrapper for AG2's MCP-enabled agent."""
+    """Agent to access a Youtube MCP Server to download closed captions"""
 
     SUPPORTED_CONTENT_TYPES = ["text", "text/plain"]
 
     def __init__(self):
         # Import AG2 dependencies here to isolate requirements
         try:
-            # Set up LLM configuration
+            # Set up LLM configuration with response format
             llm_config = LLMConfig(
-                model="gpt-4o-mini",
-                api_type="openai",
-                api_key=get_api_key()
+                model="gpt-4o",
+                api_key=get_api_key(),
+                response_format=ResponseModel
             )
 
             # Create the assistant agent that will use MCP tools
             self.agent = AssistantAgent(
-                name="MCPAgent",
+                name="YoutubeMCPAgent",
                 llm_config=llm_config,
-                system_message="You are a helpful assistant with access to MCP tools. You can solve various tasks using these tools."
+                system_message=(
+                    "You are a specialized assistant for processing YouTube videos. "
+                    "You can use MCP tools to fetch captions and process YouTube content. "
+                    "You can provide captions, summarize videos, or analyze content from YouTube. "
+                    "If the user asks about anything not related to YouTube videos or doesn't provide a YouTube URL, "
+                    "politely state that you can only help with tasks related to YouTube videos.\n\n"
+                    "IMPORTANT: Always respond using the ResponseModel format with these fields:\n"
+                    "- text_reply: Your main response text\n"
+                    "- closed_captions: YouTube captions if available, null if not relevant\n"
+                    "- status: Always use 'TERMINATE' for all responses \n\n"
+                    "Example response:\n"
+                    "{\n"
+                    "  \"text_reply\": \"Here's the information you requested...\",\n"
+                    "  \"closed_captions\": null,\n"
+                    "  \"status\": \"TERMINATE\"\n"
+                    "}"
+                ),
             )
 
             self.initialized = True
@@ -46,140 +77,104 @@ class YoutubeMCPAgent:
             logger.error(f"Failed to import AG2 components: {e}")
             self.initialized = False
 
-    async def _create_toolkit_and_run(self, query: str) -> str:
-        """Create MCP toolkit and run the query with the agent."""
+    def get_agent_response(self, response: str) -> dict[str, Any]:
+        """Format agent response in a consistent structure."""
         try:
-            # Create stdio server parameters for MCP
-            server_params = StdioServerParameters(
-                command="mcp-youtube",
-            )
-
-            logger.info(f"Creating MCP toolkit for query: {query[:50]}...")
-
-            # Connect to the MCP server using stdio client
-            async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
-                # Initialize the connection
-                await session.initialize()
-
-                # Create a toolkit with available MCP tools
-                toolkit = await create_toolkit(session=session)
-
-                # Register MCP tools with the agent
-                toolkit.register_for_llm(self.agent)
-
-                # Make a request using the MCP tools
-                result = await self.agent.a_run(
-                    message=query,
-                    tools=toolkit.tools,
-                    max_turns=2,
-                    user_input=False,
-                )
-
-                try:    
-                    # Process the result which will print the output
-                    await result.process()
-
-                    # Get the summary which by default contains the agent's last message output
-                    return await result.summary
-
-                except Exception as extraction_error:
-                    logger.error(f"Error extracting response: {extraction_error}")
-                    return f"Error extracting response from MCP agent: {str(extraction_error)}"
+            # Try to parse the response as a ResponseModel JSON
+            response_dict = json.loads(response)
+            model = ResponseModel(**response_dict)
+            
+            # All final responses should be treated as complete
+            return {
+                "is_task_complete": True,
+                "require_user_input": False,
+                "content": model.format()
+            }
         except Exception as e:
-            logger.error(f"Error using MCP toolkit: {e}")
-            raise
+            # Log but continue with best-effort fallback
+            logger.error(f"Error parsing response: {e}, response: {response}")
+            
+            # Default to treating it as a completed response
+            return {
+                "is_task_complete": True, 
+                "require_user_input": False,
+                "content": response
+            }
 
-    async def stream(self, query: str, sessionId: str) -> AsyncIterable[Dict[str, Any]]:
+    async def stream(self, query: str, sessionId: str) -> AsyncIterable[dict[str, Any]]:
         """Stream updates from the MCP agent."""
         if not self.initialized:
             yield {
                 "is_task_complete": False,
                 "require_user_input": True,
-                "content": "MCP agent initialization failed. Please check the dependencies and logs."
+                "content": "Agent initialization failed. Please check the dependencies and logs."
             }
             return
 
         try:
-            # Initial status update
+            # Initial response to acknowledge the query
             yield {
                 "is_task_complete": False,
                 "require_user_input": False,
-                "content": "Connecting to MCP server..."
+                "content": "Processing request..."
             }
 
-            logger.info(f"Processing query in stream: {query[:50]}...")
+            logger.info(f"Processing query: {query[:50]}...")
 
             try:                
-                # Create stdio server parameters for mcp-youtube 
+                # Create stdio server parameters for mcp-youtube
                 server_params = StdioServerParameters(
                     command="mcp-youtube",
                 )
-
-                # Progress update
-                yield {
-                    "is_task_complete": False,
-                    "require_user_input": False,
-                    "content": "Setting up MCP toolkit..."
-                }
 
                 # Connect to the MCP server using stdio client
                 async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
                     # Initialize the connection
                     await session.initialize()
 
-                    # Progress update
-                    yield {
-                        "is_task_complete": False,
-                        "require_user_input": False,
-                        "content": "Processing with MCP tools..."
-                    }
-
                     # Create toolkit and register tools
                     toolkit = await create_toolkit(session=session)
                     toolkit.register_for_llm(self.agent)
 
-                    # Process the request
                     result = await self.agent.a_run(
                         message=query,
                         tools=toolkit.tools,
-                        max_turns=2,
+                        max_turns=2,  # Fixed at 2 turns to allow tool usage
                         user_input=False,
                     )
 
                     # Extract the content from the result
                     try:
-                        # Process the result which will print the output
+                        # Process the result
                         await result.process()
-
+                        
                         # Get the summary which contains the output
                         response = await result.summary
 
                     except Exception as extraction_error:
                         logger.error(f"Error extracting response: {extraction_error}")
-                        response = f"Error extracting response from MCP agent: {str(extraction_error)}"
+                        traceback.print_exc()
+                        response = f"Error processing request: {str(extraction_error)}"
 
                     # Final response
-                    yield {
-                        "is_task_complete": True,
-                        "require_user_input": False,
-                        "content": response
-                    }
+                    yield self.get_agent_response(response)
+                    
             except Exception as e:
-                logger.error(f"Error during MCP processing: {traceback.format_exc()}")
+                logger.error(f"Error during processing: {traceback.format_exc()}")
                 yield {
                     "is_task_complete": False,
                     "require_user_input": True,
-                    "content": f"Error during MCP interaction: {str(e)}"
+                    "content": f"Error processing request: {str(e)}"
                 }
         except Exception as e:
-            logger.error(f"Error in streaming MCP agent: {traceback.format_exc()}")
+            logger.error(f"Error in streaming agent: {traceback.format_exc()}")
             yield {
                 "is_task_complete": False,
                 "require_user_input": True,
-                "content": f"Error during MCP interaction: {str(e)}"
+                "content": f"Error processing request: {str(e)}"
             }
 
-    def invoke(self, query: str, sessionId: str) -> Dict[str, Any]:
+    def invoke(self, query: str, sessionId: str) -> dict[str, Any]:
         """Synchronous invocation of the MCP agent."""
         raise NotImplementedError(
             "Synchronous invocation is not supported by this agent. Use the streaming endpoint (tasks/sendSubscribe) instead."

--- a/samples/python/agents/ag2/agent.py
+++ b/samples/python/agents/ag2/agent.py
@@ -1,0 +1,186 @@
+import asyncio
+import logging
+import os
+import traceback
+from dotenv import load_dotenv
+from typing import AsyncIterable, Dict, Any
+
+from autogen import AssistantAgent, LLMConfig
+from autogen.mcp import create_toolkit
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+logger = logging.getLogger(__name__)
+
+def get_api_key() -> str:
+    """Helper method to handle API Key."""
+    load_dotenv()
+    return os.getenv("OPENAI_API_KEY")
+
+class YoutubeMCPAgent:
+    """A2A-compatible wrapper for AG2's MCP-enabled agent."""
+
+    SUPPORTED_CONTENT_TYPES = ["text", "text/plain"]
+
+    def __init__(self):
+        # Import AG2 dependencies here to isolate requirements
+        try:
+            # Set up LLM configuration
+            llm_config = LLMConfig(
+                model="gpt-4o-mini",
+                api_type="openai",
+                api_key=get_api_key()
+            )
+
+            # Create the assistant agent that will use MCP tools
+            self.agent = AssistantAgent(
+                name="MCPAgent",
+                llm_config=llm_config,
+                system_message="You are a helpful assistant with access to MCP tools. You can solve various tasks using these tools."
+            )
+
+            self.initialized = True
+            logger.info("MCP Agent initialized successfully")
+        except ImportError as e:
+            logger.error(f"Failed to import AG2 components: {e}")
+            self.initialized = False
+
+    async def _create_toolkit_and_run(self, query: str) -> str:
+        """Create MCP toolkit and run the query with the agent."""
+        try:
+            # Create stdio server parameters for MCP
+            server_params = StdioServerParameters(
+                command="mcp-youtube",
+            )
+
+            logger.info(f"Creating MCP toolkit for query: {query[:50]}...")
+
+            # Connect to the MCP server using stdio client
+            async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+                # Initialize the connection
+                await session.initialize()
+
+                # Create a toolkit with available MCP tools
+                toolkit = await create_toolkit(session=session)
+
+                # Register MCP tools with the agent
+                toolkit.register_for_llm(self.agent)
+
+                # Make a request using the MCP tools
+                result = await self.agent.a_run(
+                    message=query,
+                    tools=toolkit.tools,
+                    max_turns=2,
+                    user_input=False,
+                )
+
+                try:    
+                    # Process the result which will print the output
+                    await result.process()
+
+                    # Get the summary which by default contains the agent's last message output
+                    return await result.summary
+
+                except Exception as extraction_error:
+                    logger.error(f"Error extracting response: {extraction_error}")
+                    return f"Error extracting response from MCP agent: {str(extraction_error)}"
+        except Exception as e:
+            logger.error(f"Error using MCP toolkit: {e}")
+            raise
+
+    async def stream(self, query: str, sessionId: str) -> AsyncIterable[Dict[str, Any]]:
+        """Stream updates from the MCP agent."""
+        if not self.initialized:
+            yield {
+                "is_task_complete": False,
+                "require_user_input": True,
+                "content": "MCP agent initialization failed. Please check the dependencies and logs."
+            }
+            return
+
+        try:
+            # Initial status update
+            yield {
+                "is_task_complete": False,
+                "require_user_input": False,
+                "content": "Connecting to MCP server..."
+            }
+
+            logger.info(f"Processing query in stream: {query[:50]}...")
+
+            try:                
+                # Create stdio server parameters for mcp-youtube 
+                server_params = StdioServerParameters(
+                    command="mcp-youtube",
+                )
+
+                # Progress update
+                yield {
+                    "is_task_complete": False,
+                    "require_user_input": False,
+                    "content": "Setting up MCP toolkit..."
+                }
+
+                # Connect to the MCP server using stdio client
+                async with stdio_client(server_params) as (read, write), ClientSession(read, write) as session:
+                    # Initialize the connection
+                    await session.initialize()
+
+                    # Progress update
+                    yield {
+                        "is_task_complete": False,
+                        "require_user_input": False,
+                        "content": "Processing with MCP tools..."
+                    }
+
+                    # Create toolkit and register tools
+                    toolkit = await create_toolkit(session=session)
+                    toolkit.register_for_llm(self.agent)
+
+                    # Process the request
+                    result = await self.agent.a_run(
+                        message=query,
+                        tools=toolkit.tools,
+                        max_turns=2,
+                        user_input=False,
+                    )
+
+                    # Extract the content from the result
+                    try:
+                        # Process the result which will print the output
+                        await result.process()
+
+                        # Get the summary which contains the output
+                        response = await result.summary
+
+                    except Exception as extraction_error:
+                        logger.error(f"Error extracting response: {extraction_error}")
+                        response = f"Error extracting response from MCP agent: {str(extraction_error)}"
+
+                    # Final response
+                    yield {
+                        "is_task_complete": True,
+                        "require_user_input": False,
+                        "content": response
+                    }
+            except Exception as e:
+                logger.error(f"Error during MCP processing: {traceback.format_exc()}")
+                yield {
+                    "is_task_complete": False,
+                    "require_user_input": True,
+                    "content": f"Error during MCP interaction: {str(e)}"
+                }
+        except Exception as e:
+            logger.error(f"Error in streaming MCP agent: {traceback.format_exc()}")
+            yield {
+                "is_task_complete": False,
+                "require_user_input": True,
+                "content": f"Error during MCP interaction: {str(e)}"
+            }
+
+    def invoke(self, query: str, sessionId: str) -> Dict[str, Any]:
+        """Synchronous invocation of the MCP agent."""
+        raise NotImplementedError(
+            "Synchronous invocation is not supported by this agent. Use the streaming endpoint (tasks/sendSubscribe) instead."
+        )

--- a/samples/python/agents/ag2/pyproject.toml
+++ b/samples/python/agents/ag2/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "a2a-samples-mcp"
+version = "0.1.0"
+description = "MCP agent using A2A and AG2"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "ag2>=0.8.6",
+    "ag2[mcp, openai]>=0.8.6",
+    "google-genai>=1.10.0",
+    "a2a-samples",
+]
+
+[tool.uv.sources]
+a2a-samples = { workspace = true }

--- a/samples/python/agents/ag2/task_manager.py
+++ b/samples/python/agents/ag2/task_manager.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterable, Union
+from typing import AsyncIterable
 from common.types import (
     SendTaskRequest,
     TaskSendParams,
@@ -13,8 +13,7 @@ from common.types import (
     SendTaskStreamingRequest,
     SendTaskStreamingResponse,
     TaskArtifactUpdateEvent,
-    TaskStatusUpdateEvent,
-    Task,
+    TaskStatusUpdateEvent
 )
 from common.server.task_manager import InMemoryTaskManager
 from .agent import YoutubeMCPAgent
@@ -33,87 +32,50 @@ class AgentTaskManager(InMemoryTaskManager):
         super().__init__()
         self.agent = agent
 
+    # -------------------------------------------------------------
+    # Public API methods
+    # -------------------------------------------------------------
+
     async def on_send_task(self, request: SendTaskRequest) -> SendTaskResponse:
-        """Handle synchronous task requests."""
+        """
+        Handle synchronous task requests.
+        
+        This method processes one-time task requests and returns a complete response.
+        Unlike streaming tasks, this waits for the full agent response before returning.
+        """
         validation_error = self._validate_request(request)
         if validation_error:
             return SendTaskResponse(id=request.id, error=validation_error.error)
         
         await self.upsert_task(request.params)
-        task = await self.update_store(
+        # Update task store to WORKING state (return value not used)
+        await self.update_store(
             request.params.id, TaskStatus(state=TaskState.WORKING), None
         )
 
         task_send_params: TaskSendParams = request.params
-        query = self._get_user_query(task_send_params)
+        query = self._extract_user_query(task_send_params)
         
         try:
             agent_response = self.agent.invoke(query, task_send_params.sessionId)
-            return await self._process_agent_response(request, agent_response)
+            return await self._handle_send_task(request, agent_response)
         except Exception as e:
             logger.error(f"Error invoking agent: {e}")
             return SendTaskResponse(
                 id=request.id, 
-                error=InternalError(message=f"Error during Discord interaction: {str(e)}")
-            )
-
-    async def _run_streaming_agent(self, request: SendTaskStreamingRequest):
-        task_send_params: TaskSendParams = request.params
-        query = self._get_user_query(task_send_params)
-
-        try:
-            async for item in self.agent.stream(query, task_send_params.sessionId):
-                is_task_complete = item["is_task_complete"]
-                require_user_input = item["require_user_input"]
-                artifact = None
-                message = None
-                parts = [TextPart(type="text", text=item["content"])]
-                end_stream = False
-
-                if not is_task_complete and not require_user_input:
-                    task_state = TaskState.WORKING
-                    message = Message(role="agent", parts=parts)
-                elif require_user_input:
-                    task_state = TaskState.INPUT_REQUIRED
-                    message = Message(role="agent", parts=parts)
-                    end_stream = True
-                else:
-                    task_state = TaskState.COMPLETED
-                    artifact = Artifact(parts=parts, index=0, append=False)
-                    end_stream = True
-
-                task_status = TaskStatus(state=task_state, message=message)
-                latest_task = await self.update_store(
-                    task_send_params.id,
-                    task_status,
-                    None if artifact is None else [artifact],
-                )
-
-                if artifact:
-                    task_artifact_update_event = TaskArtifactUpdateEvent(
-                        id=task_send_params.id, artifact=artifact
-                    )
-                    await self.enqueue_events_for_sse(
-                        task_send_params.id, task_artifact_update_event
-                    )                    
-                    
-                task_update_event = TaskStatusUpdateEvent(
-                    id=task_send_params.id, status=task_status, final=end_stream
-                )
-                await self.enqueue_events_for_sse(
-                    task_send_params.id, task_update_event
-                )
-
-        except Exception as e:
-            logger.error(f"An error occurred while streaming the response: {e}")
-            await self.enqueue_events_for_sse(
-                task_send_params.id,
-                InternalError(message=f"An error occurred while streaming the response: {e}")                
+                error=InternalError(message=f"Error during on_send_task: {str(e)}")
             )
 
     async def on_send_task_subscribe(
         self, request: SendTaskStreamingRequest
     ) -> AsyncIterable[SendTaskStreamingResponse] | JSONRPCResponse:
+        """
+        Handle streaming task requests with SSE subscription.
+        
+        This method initiates a streaming task and returns incremental updates
+        to the client as they become available. It uses Server-Sent Events (SSE)
+        to push updates to the client as the agent generates them.
+        """
         try:
             error = self._validate_request(request)
             if error:
@@ -124,7 +86,7 @@ class AgentTaskManager(InMemoryTaskManager):
             task_send_params: TaskSendParams = request.params
             sse_event_queue = await self.setup_sse_consumer(task_send_params.id, False)            
 
-            asyncio.create_task(self._run_streaming_agent(request))
+            asyncio.create_task(self._handle_send_task_streaming(request))
 
             return self.dequeue_events_for_sse(
                 request.id, task_send_params.id, sse_event_queue
@@ -139,25 +101,20 @@ class AgentTaskManager(InMemoryTaskManager):
                 ),
             )
 
-    def _validate_request(
-        self, request: Union[SendTaskRequest, SendTaskStreamingRequest]
-    ) -> JSONRPCResponse | None:
-        task_send_params: TaskSendParams = request.params
-        if not utils.are_modalities_compatible(
-            task_send_params.acceptedOutputModes, YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES
-        ):
-            logger.warning(
-                "Unsupported output mode. Received %s, Support %s",
-                task_send_params.acceptedOutputModes,
-                YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES,
-            )
-            return utils.new_incompatible_types_error(request.id)
-        return None
-        
-    async def _process_agent_response(
+    # -------------------------------------------------------------
+    # Agent response handlers
+    # -------------------------------------------------------------
+
+    async def _handle_send_task(
         self, request: SendTaskRequest, agent_response: dict
     ) -> SendTaskResponse:
-        """Processes the agent's response and updates the task store."""
+        """
+        Handle the 'tasks/send' JSON-RPC method by processing agent response.
+        
+        This method processes the synchronous (one-time) response from the agent,
+        transforms it into the appropriate task status and artifacts, and 
+        returns a complete SendTaskResponse.
+        """
         task_send_params: TaskSendParams = request.params
         task_id = task_send_params.id
         history_length = task_send_params.historyLength
@@ -173,13 +130,136 @@ class AgentTaskManager(InMemoryTaskManager):
         else:
             task_status = TaskStatus(state=TaskState.COMPLETED)
             artifact = Artifact(parts=parts)
-        task = await self.update_store(
+        # Update task store and get result for response
+        updated_task = await self.update_store(
             task_id, task_status, None if artifact is None else [artifact]
         )
-        task_result = self.append_task_history(task, history_length)
+        # Use the updated task to create a response with correct history
+        task_result = self.append_task_history(updated_task, history_length)
         return SendTaskResponse(id=request.id, result=task_result)
-    
-    def _get_user_query(self, task_send_params: TaskSendParams) -> str:
+
+    async def _handle_send_task_streaming(self, request: SendTaskStreamingRequest):
+        """
+        Handle the 'tasks/sendSubscribe' JSON-RPC method for streaming responses.
+        
+        This method processes streaming responses from the agent incrementally,
+        converting each chunk into appropriate SSE events for real-time client updates.
+        It handles different agent response states (working, input required, completed)
+        and generates both status update and artifact events.
+        """
+        task_send_params: TaskSendParams = request.params
+        query = self._extract_user_query(task_send_params)
+
+        try:
+            async for item in self.agent.stream(query, task_send_params.sessionId):
+                is_task_complete = item["is_task_complete"]
+                require_user_input = item["require_user_input"]
+                content = item["content"]
+                
+                logger.info(f"Stream item received: complete={is_task_complete}, require_input={require_user_input}, content_len={len(content)}")
+                
+                artifact = None
+                message = None
+                parts = [TextPart(type="text", text=content)]
+                end_stream = False
+
+                if not is_task_complete and not require_user_input:
+                    # Processing message - working state
+                    task_state = TaskState.WORKING
+                    message = Message(role="agent", parts=parts)
+                    logger.info(f"Sending WORKING status update")
+                elif require_user_input:
+                    # Requires user input - input required state
+                    task_state = TaskState.INPUT_REQUIRED
+                    message = Message(role="agent", parts=parts)
+                    end_stream = True
+                    logger.info(f"Sending INPUT_REQUIRED status update (final)")
+                else:
+                    # Task completed - completed state with artifact
+                    task_state = TaskState.COMPLETED
+                    artifact = Artifact(parts=parts, index=0, append=False)
+                    end_stream = True
+                    logger.info(f"Sending COMPLETED status with artifact (final)")
+
+                # Update task store (return value not used)
+                task_status = TaskStatus(state=task_state, message=message)
+                await self.update_store(
+                    task_send_params.id,
+                    task_status,
+                    None if artifact is None else [artifact],
+                )
+
+                # First send artifact if we have one
+                if artifact:
+                    logger.info(f"Sending artifact event for task {task_send_params.id}")
+                    task_artifact_update_event = TaskArtifactUpdateEvent(
+                        id=task_send_params.id, artifact=artifact
+                    )
+                    await self.enqueue_events_for_sse(
+                        task_send_params.id, task_artifact_update_event
+                    )                    
+                
+                # Then send status update
+                logger.info(f"Sending status update for task {task_send_params.id}, state={task_state}, final={end_stream}")
+                task_update_event = TaskStatusUpdateEvent(
+                    id=task_send_params.id, status=task_status, final=end_stream
+                )
+                await self.enqueue_events_for_sse(
+                    task_send_params.id, task_update_event
+                )
+
+        except Exception as e:
+            logger.error(f"An error occurred while streaming the response: {e}")
+            logger.error(traceback.format_exc())
+            await self.enqueue_events_for_sse(
+                task_send_params.id,
+                InternalError(message=f"An error occurred while streaming the response: {e}")                
+            )
+
+    # -------------------------------------------------------------
+    # Utility methods
+    # -------------------------------------------------------------
+
+    def _validate_request(
+        self, request: SendTaskRequest | SendTaskStreamingRequest
+    ) -> JSONRPCResponse | None:
+        """
+        Validate task request parameters for compatibility with agent capabilities.
+        
+        Ensures that the client's requested output modalities are compatible with
+        what the agent can provide.
+        
+        Returns:
+            JSONRPCResponse with an error if validation fails, None otherwise.
+        """
+        task_send_params: TaskSendParams = request.params
+        if not utils.are_modalities_compatible(
+            task_send_params.acceptedOutputModes, YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES
+        ):
+            logger.warning(
+                "Unsupported output mode. Received %s, Support %s",
+                task_send_params.acceptedOutputModes,
+                YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES,
+            )
+            return utils.new_incompatible_types_error(request.id)
+        return None
+        
+    def _extract_user_query(self, task_send_params: TaskSendParams) -> str:
+        """
+        Extract the user's text query from the task parameters.
+        
+        Extracts and returns the text content from the first part of the user's message.
+        Currently only supports text parts.
+        
+        Args:
+            task_send_params: The parameters of the task containing the user's message.
+            
+        Returns:
+            str: The extracted text query.
+            
+        Raises:
+            ValueError: If the message part is not a TextPart.
+        """
         part = task_send_params.message.parts[0]
         if not isinstance(part, TextPart):
             raise ValueError("Only text parts are supported")

--- a/samples/python/agents/ag2/task_manager.py
+++ b/samples/python/agents/ag2/task_manager.py
@@ -1,0 +1,186 @@
+from typing import AsyncIterable, Union
+from common.types import (
+    SendTaskRequest,
+    TaskSendParams,
+    Message,
+    TaskStatus,
+    Artifact,
+    TextPart,
+    TaskState,
+    SendTaskResponse,
+    InternalError,
+    JSONRPCResponse,
+    SendTaskStreamingRequest,
+    SendTaskStreamingResponse,
+    TaskArtifactUpdateEvent,
+    TaskStatusUpdateEvent,
+    Task,
+)
+from common.server.task_manager import InMemoryTaskManager
+from .agent import YoutubeMCPAgent
+import common.server.utils as utils
+import asyncio
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
+class AgentTaskManager(InMemoryTaskManager):
+    """Task manager for AG2 MCP agent."""
+    
+    def __init__(self, agent: YoutubeMCPAgent):
+        super().__init__()
+        self.agent = agent
+
+    async def on_send_task(self, request: SendTaskRequest) -> SendTaskResponse:
+        """Handle synchronous task requests."""
+        validation_error = self._validate_request(request)
+        if validation_error:
+            return SendTaskResponse(id=request.id, error=validation_error.error)
+        
+        await self.upsert_task(request.params)
+        task = await self.update_store(
+            request.params.id, TaskStatus(state=TaskState.WORKING), None
+        )
+
+        task_send_params: TaskSendParams = request.params
+        query = self._get_user_query(task_send_params)
+        
+        try:
+            agent_response = self.agent.invoke(query, task_send_params.sessionId)
+            return await self._process_agent_response(request, agent_response)
+        except Exception as e:
+            logger.error(f"Error invoking agent: {e}")
+            return SendTaskResponse(
+                id=request.id, 
+                error=InternalError(message=f"Error during Discord interaction: {str(e)}")
+            )
+
+    async def _run_streaming_agent(self, request: SendTaskStreamingRequest):
+        task_send_params: TaskSendParams = request.params
+        query = self._get_user_query(task_send_params)
+
+        try:
+            async for item in self.agent.stream(query, task_send_params.sessionId):
+                is_task_complete = item["is_task_complete"]
+                require_user_input = item["require_user_input"]
+                artifact = None
+                message = None
+                parts = [TextPart(type="text", text=item["content"])]
+                end_stream = False
+
+                if not is_task_complete and not require_user_input:
+                    task_state = TaskState.WORKING
+                    message = Message(role="agent", parts=parts)
+                elif require_user_input:
+                    task_state = TaskState.INPUT_REQUIRED
+                    message = Message(role="agent", parts=parts)
+                    end_stream = True
+                else:
+                    task_state = TaskState.COMPLETED
+                    artifact = Artifact(parts=parts, index=0, append=False)
+                    end_stream = True
+
+                task_status = TaskStatus(state=task_state, message=message)
+                latest_task = await self.update_store(
+                    task_send_params.id,
+                    task_status,
+                    None if artifact is None else [artifact],
+                )
+
+                if artifact:
+                    task_artifact_update_event = TaskArtifactUpdateEvent(
+                        id=task_send_params.id, artifact=artifact
+                    )
+                    await self.enqueue_events_for_sse(
+                        task_send_params.id, task_artifact_update_event
+                    )                    
+                    
+                task_update_event = TaskStatusUpdateEvent(
+                    id=task_send_params.id, status=task_status, final=end_stream
+                )
+                await self.enqueue_events_for_sse(
+                    task_send_params.id, task_update_event
+                )
+
+        except Exception as e:
+            logger.error(f"An error occurred while streaming the response: {e}")
+            await self.enqueue_events_for_sse(
+                task_send_params.id,
+                InternalError(message=f"An error occurred while streaming the response: {e}")                
+            )
+
+    async def on_send_task_subscribe(
+        self, request: SendTaskStreamingRequest
+    ) -> AsyncIterable[SendTaskStreamingResponse] | JSONRPCResponse:
+        try:
+            error = self._validate_request(request)
+            if error:
+                return error
+
+            await self.upsert_task(request.params)
+
+            task_send_params: TaskSendParams = request.params
+            sse_event_queue = await self.setup_sse_consumer(task_send_params.id, False)            
+
+            asyncio.create_task(self._run_streaming_agent(request))
+
+            return self.dequeue_events_for_sse(
+                request.id, task_send_params.id, sse_event_queue
+            )
+        except Exception as e:
+            logger.error(f"Error in SSE stream: {e}")
+            print(traceback.format_exc())
+            return JSONRPCResponse(
+                id=request.id,
+                error=InternalError(
+                    message="An error occurred while streaming the response"
+                ),
+            )
+
+    def _validate_request(
+        self, request: Union[SendTaskRequest, SendTaskStreamingRequest]
+    ) -> JSONRPCResponse | None:
+        task_send_params: TaskSendParams = request.params
+        if not utils.are_modalities_compatible(
+            task_send_params.acceptedOutputModes, YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES
+        ):
+            logger.warning(
+                "Unsupported output mode. Received %s, Support %s",
+                task_send_params.acceptedOutputModes,
+                YoutubeMCPAgent.SUPPORTED_CONTENT_TYPES,
+            )
+            return utils.new_incompatible_types_error(request.id)
+        return None
+        
+    async def _process_agent_response(
+        self, request: SendTaskRequest, agent_response: dict
+    ) -> SendTaskResponse:
+        """Processes the agent's response and updates the task store."""
+        task_send_params: TaskSendParams = request.params
+        task_id = task_send_params.id
+        history_length = task_send_params.historyLength
+        task_status = None
+
+        parts = [TextPart(type="text", text=agent_response["content"])]
+        artifact = None
+        if agent_response["require_user_input"]:
+            task_status = TaskStatus(
+                state=TaskState.INPUT_REQUIRED,
+                message=Message(role="agent", parts=parts),
+            )
+        else:
+            task_status = TaskStatus(state=TaskState.COMPLETED)
+            artifact = Artifact(parts=parts)
+        task = await self.update_store(
+            task_id, task_status, None if artifact is None else [artifact]
+        )
+        task_result = self.append_task_history(task, history_length)
+        return SendTaskResponse(id=request.id, result=task_result)
+    
+    def _get_user_query(self, task_send_params: TaskSendParams) -> str:
+        part = task_send_params.message.parts[0]
+        if not isinstance(part, TextPart):
+            raise ValueError("Only text parts are supported")
+        return part.text

--- a/samples/python/agents/google_adk/agent.py
+++ b/samples/python/agents/google_adk/agent.py
@@ -126,9 +126,9 @@ class ReimbursementAgent:
           state={},
           session_id=session_id,
       )
-    events = self._runner.run(
+    events = list(self._runner.run(
         user_id=self._user_id, session_id=session.id, new_message=content
-    )
+    ))
     if not events or not events[-1].content or not events[-1].content.parts:
       return ""
     return "\n".join([p.text for p in events[-1].content.parts if p.text])

--- a/samples/python/agents/semantickernel/README.md
+++ b/samples/python/agents/semantickernel/README.md
@@ -1,0 +1,161 @@
+# Semantic Kernel Agent with A2A Protocol
+
+This sample demonstrates how to implement a travel agent built on [Semantic Kernel](https://github.com/microsoft/semantic-kernel/) and exposed through the A2A protocol. It showcases:
+
+- **Multi-turn interactions**: The agent may request clarifications
+- **Streaming responses**: Returns incremental statuses
+- **Conversational memory**: Maintains context (by leveraging Semantic Kernel’s ChatHistory)
+- **Push notifications**: Uses webhook-based notifications for asynchronous updates
+- **External plugins (SK Agents & Frankfurter API)**: Illustrates how an Semantic Kernel Agents are used as plugins, along with APIs, that can be called to generate travel plans and fetch exchange rates
+
+```mermaid
+sequenceDiagram
+    participant Client as A2A Client
+    participant Server as A2A Server
+    participant TM as TravelManagerAgent 
+    participant CE as CurrencyExchangeAgent (Plugin)
+    participant AP as ActivityPlannerAgent (Plugin)
+    participant API as Frankfurter API (Plugin)
+
+    Client->>Server: Send task (trip query with budget)
+    Server->>TM: Forward trip planning query
+
+    Note over TM: Analyze and delegate tasks
+    par Currency Exchange Flow
+        TM->>CE: How much is $100 USD in KRW?
+        CE->>API: Call get_exchange_rate tool
+        API->>CE: Return exchange rate
+        CE->>TM: Return currency conversion
+    and Activity Planning Flow
+        TM->>AP: Recommend itinerary for $100 budget
+        AP->>TM: Return itinerary recommendations
+    end
+
+    TM->>Server: Aggregate currency & itinerary
+    Server->>Client: Streaming: "Processing the trip plan (tool calls involved)..."
+    Server->>Client: Streaming: "Building the trip plan..."
+    Server->>Client: Artifact: Final trip plan with budget details
+    Server->>Client: Final status: "Task completed."
+```
+
+## Prerequisites
+
+- Python 3.10 or higher
+- uv
+- Valid OpenAI/Azure OpenAI or other LLM credentials (depending on your SK setup). See [here](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/?tabs=csharp-AzureOpenAI%2Cpython-AzureOpenAI%2Cjava-AzureOpenAI&pivots=programming-language-python#creating-a-chat-completion-service) for more details about Semantic Kernel AI connectors that are used with a ChatCompletionAgent.
+- Access to a Frankfurter API key (optional, or you can call the free endpoint)
+
+## Setup & Running
+
+1. **Navigate to the samples directory**:
+
+```bash
+cd samples/python/agents/semantickernel
+```
+
+2. **Create an environment file (.env) with your API key and the model ID (e.g., "gpt-4.1"):**:
+
+```bash
+OPENAI_API_KEY="your_api_key_here"
+OPENAI_CHAT_MODEL_ID="your-model-id"
+```
+
+3. **Set up the Python Environment**:
+
+> Note: pin the Python version to your desired version (3.10+)
+
+```bash
+uv python pin 3.12
+uv venv
+source .venv/bin/activate
+```
+4. **Run the agent**:
+
+Choose one of the following options:
+
+> Make sure you run `uv run .` from the following directory: `samples/python/agents/semantickernel`
+
+```bash
+# Basic run on default port 10020
+uv run .
+```
+or
+
+```bash
+# On custom host/port
+uv run . --host 0.0.0.0 --port 8080
+```
+
+5. **In a separate terminal, run the A2A client:
+
+> Make sure you run `uv run hosts/cli` from the following directory: `samples/python`
+
+```bash
+uv run hosts/cli --agent http://localhost:10020
+```
+
+## Limitations
+
+- Only text-based input/output for now
+- Frankfurter API has a limited set of currency conversions
+- Session-based memory is ephemeral (in-memory)
+
+## Example Endpoints
+
+You can POST A2A requests to http://localhost:10020 with JSON-RPC specifying tasks/send or tasks/sendSubscribe. Here is a synchronous snippet:
+
+### Request:
+
+POST http://localhost:10020
+Content-Type: application/json
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 33,
+  "method": "tasks/send",
+  "params": {
+    "id": "3",
+    "sessionId": "1aab49f1e85c499da48c2124f4ceee4d",
+    "acceptedOutputModes": ["text"],
+    "message": {
+      "role": "user",
+      "parts": [
+        { "type": "text", "text": "How much is 1 USD to EUR?" }
+      ]
+    }
+  }
+}
+```
+
+### Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 33,
+  "result": {
+    "id": "3",
+    "status": {
+      "state": "completed",
+      "timestamp": "2025-04-01T16:53:29.301828"
+    },
+    "artifacts": [
+      {
+        "parts": [
+          {
+            "type": "text",
+            "text": "1 USD is approximately 0.88137 EUR."
+          }
+        ],
+        "index": 0
+      }
+    ],
+    "history": []
+  }
+}
+```
+
+And so on for multi-turn, streaming, etc.
+
+For more details, see [A2A Protocol Documentation](https://google.github.io/A2A/#/documentation) and [Semantic Kernel Docs](https://learn.microsoft.com/en-us/semantic-kernel/get-started/quick-start-guide?pivots=programming-language-python).

--- a/samples/python/agents/semantickernel/__main__.py
+++ b/samples/python/agents/semantickernel/__main__.py
@@ -1,0 +1,66 @@
+import logging
+
+import click
+from common.server import A2AServer
+from common.types import AgentCapabilities, AgentCard, AgentSkill
+from common.utils.push_notification_auth import PushNotificationSenderAuth
+from dotenv import load_dotenv
+
+from agents.semantickernel.task_manager import TaskManager
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+
+@click.command()
+@click.option("--host", default="localhost")
+@click.option("--port", default=10020)
+def main(host, port):
+    """Starts the Semantic Kernel Agent server using A2A."""
+    # Build the agent card
+    capabilities = AgentCapabilities(streaming=True, pushNotifications=True)
+    skill_trip_planning = AgentSkill(
+        id="trip_planning_sk",
+        name="Semantic Kernel Trip Planning",
+        description=(
+            "Handles comprehensive trip planning, including currency exchanges, itinerary creation, sightseeing, "
+            "dining recommendations, and event bookings using Frankfurter API for currency conversions."
+        ),
+        tags=["trip", "planning", "travel", "currency", "semantic-kernel"],
+        examples=[
+            "Plan a budget-friendly day trip to Seoul including currency exchange.", 
+            "What's the exchange rate and recommended itinerary for visiting Tokyo?",
+        ]
+    )
+
+    agent_card = AgentCard(
+        name="SK Travel Agent",
+        description=(
+            "Semantic Kernel-based travel agent providing comprehensive trip planning services "
+            "including currency exchange and personalized activity planning."
+        ),
+        url=f"http://{host}:{port}/",
+        version="1.0.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=capabilities,
+        skills=[skill_trip_planning],
+    )
+
+    # Prepare push notification system
+    notification_sender_auth = PushNotificationSenderAuth()
+    notification_sender_auth.generate_jwk()
+
+    # Create the server
+    task_manager = TaskManager(notification_sender_auth=notification_sender_auth)
+    server = A2AServer(agent_card=agent_card, task_manager=task_manager, host=host, port=port)
+    server.app.add_route("/.well-known/jwks.json", notification_sender_auth.handle_jwks_endpoint, methods=["GET"])
+
+    logger.info(f"Starting the Semantic Kernel agent server on {host}:{port}")
+    server.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/agents/semantickernel/agent.py
+++ b/samples/python/agents/semantickernel/agent.py
@@ -1,0 +1,243 @@
+import os
+import httpx
+import logging
+from typing import Any, AsyncIterable, Annotated, Literal, TYPE_CHECKING
+
+from dotenv import load_dotenv
+
+from pydantic import BaseModel
+
+from semantic_kernel.agents import ChatCompletionAgent, ChatHistoryAgentThread
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion, OpenAIChatPromptExecutionSettings
+from semantic_kernel.contents import (
+    FunctionCallContent, FunctionResultContent, StreamingChatMessageContent, StreamingTextContent
+)
+from semantic_kernel.functions.kernel_arguments import KernelArguments
+from semantic_kernel.functions import kernel_function
+
+if TYPE_CHECKING:
+    from semantic_kernel.contents import ChatMessageContent
+
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+# region Plugin
+
+class CurrencyPlugin:
+    """A simple currency plugin that leverages Frankfurter for exchange rates.
+    
+    The Plugin is used by the `currency_exchange_agent`.
+    """
+
+    @kernel_function(description="Retrieves exchange rate between currency_from and currency_to using Frankfurter API")
+    def get_exchange_rate(
+        self,
+        currency_from: Annotated[str, "Currency code to convert from, e.g. USD"],
+        currency_to: Annotated[str, "Currency code to convert to, e.g. EUR or INR"],
+        date: Annotated[str, "Date or 'latest'"] = "latest",
+    ) -> str:
+        try:
+            response = httpx.get(
+                f"https://api.frankfurter.app/{date}", params={"from": currency_from, "to": currency_to}, timeout=10.0
+            )
+            response.raise_for_status()
+            data = response.json()
+            if "rates" not in data or currency_to not in data["rates"]:
+                return f"Could not retrieve rate for {currency_from} to {currency_to}"
+            rate = data["rates"][currency_to]
+            return f"1 {currency_from} = {rate} {currency_to}"
+        except Exception as e:
+            return f"Currency API call failed: {str(e)}"
+        
+# endregion
+
+# region Response Format
+
+class ResponseFormat(BaseModel):
+    """A Response Format model to direct how the model should respond."""
+    status: Literal["input_required", "completed", "error"] = "input_required"
+    message: str
+
+# endregion
+
+# region Semantic Kernel Agent
+
+class SemanticKernelTravelAgent:
+    """Wraps Semantic Kernel-based agents to handle Travel related tasks."""
+
+    agent: ChatCompletionAgent
+    thread: ChatHistoryAgentThread = None
+    SUPPORTED_CONTENT_TYPES = ["text", "text/plain"]
+
+    def __init__(self):
+
+        api_key = os.getenv("OPENAI_API_KEY", None)
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY environment variable not set.")
+        
+        model_id = os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-4.1")
+
+        # Define a CurrencyExchangeAgent to handle currency-related tasks
+        currency_exchange_agent = ChatCompletionAgent(
+            service=OpenAIChatCompletion(
+                api_key=api_key,
+                ai_model_id=model_id,
+            ),
+            name="CurrencyExchangeAgent",
+            instructions=(
+                "You specialize in handling currency-related requests from travelers. "
+                "This includes providing current exchange rates, converting amounts between different currencies, "
+                "explaining fees or charges related to currency exchange, and giving advice on the best practices for exchanging currency. "
+                "Your goal is to assist travelers promptly and accurately with all currency-related questions."
+            ),
+            plugins=[CurrencyPlugin()],
+        )
+
+        # Define an ActivityPlannerAgent to handle activity-related tasks
+        activity_planner_agent = ChatCompletionAgent(
+            service=OpenAIChatCompletion(
+                api_key=api_key,
+                ai_model_id=model_id,
+            ),
+            name="ActivityPlannerAgent",
+            instructions=(
+                "You specialize in planning and recommending activities for travelers. "
+                "This includes suggesting sightseeing options, local events, dining recommendations, "
+                "booking tickets for attractions, advising on travel itineraries, and ensuring activities "
+                "align with traveler preferences and schedule. "
+                "Your goal is to create enjoyable and personalized experiences for travelers."
+            ),
+        )
+
+        # Define the main TravelManagerAgent to delegate tasks to the appropriate agents
+        self.agent = ChatCompletionAgent(
+            service=OpenAIChatCompletion(
+                api_key=api_key,
+                ai_model_id=model_id,
+            ),
+            name="TravelManagerAgent",
+            instructions=(
+                "Your role is to carefully analyze the traveler's request and forward it to the appropriate agent based on the "
+                "specific details of the query. "
+                "Forward any requests involving monetary amounts, currency exchange rates, currency conversions, fees related "
+                "to currency exchange, financial transactions, or payment methods to the CurrencyExchangeAgent. "
+                "Forward requests related to planning activities, sightseeing recommendations, dining suggestions, event "
+                "booking, itinerary creation, or any experiential aspects of travel that do not explicitly involve monetary "
+                "transactions to the ActivityPlannerAgent. "
+                "Your primary goal is precise and efficient delegation to ensure travelers receive accurate and specialized "
+                "assistance promptly."
+            ),
+            plugins=[currency_exchange_agent, activity_planner_agent],
+            arguments=KernelArguments(
+                settings=OpenAIChatPromptExecutionSettings(
+                    response_format=ResponseFormat,
+                )
+            ),
+        )
+
+
+    async def invoke(self, user_input: str, session_id: str) -> dict[str, Any]:
+        """Handle synchronous tasks (like tasks/send).
+        
+        Args:
+            user_input (str): User input message.
+            session_id (str): Unique identifier for the session.
+
+        Returns:
+            dict: A dictionary containing the content, task completion status, and user input requirement.
+        """
+        await self._ensure_thread_exists(session_id)
+
+        # Use SK’s get_response for a single shot
+        response = await self.agent.get_response(
+            messages=user_input,
+            thread=self.thread,
+        )
+        return self._get_agent_response(response.content)
+
+    async def stream(self, user_input: str, session_id: str) -> AsyncIterable[dict[str, Any]]:
+        """For streaming tasks (like tasks/sendSubscribe), we yield partial progress using SK agent's invoke_stream.
+
+        Args:
+            user_input (str): User input message.
+            session_id (str): Unique identifier for the session.
+
+        Yields:
+            dict: A dictionary containing the content, task completion status, and user input requirement.
+        """
+        await self._ensure_thread_exists(session_id)
+        
+        chunks: list[StreamingChatMessageContent] = []
+
+        # For the sample, to avoid too many messages, only show one "in-progress" message for each task
+        tool_call_in_progress = False
+        message_in_progress = False
+        async for response_chunk in self.agent.invoke_stream(
+            messages=user_input, thread=self.thread,
+        ):
+            if any(isinstance(item, (FunctionCallContent, FunctionResultContent)) for item in response_chunk.items):
+                if not tool_call_in_progress:
+                    yield {
+                        "is_task_complete": False,
+                        "require_user_input": False,
+                        "content": "Processing the trip plan (with plugins)...",
+                    }
+                    tool_call_in_progress = True
+            elif any(isinstance(item, StreamingTextContent) for item in response_chunk.items):
+                if not message_in_progress:
+                    yield {
+                        "is_task_complete": False,
+                        "require_user_input": False,
+                        "content": "Building the trip plan...",
+                    }
+                    message_in_progress = True
+
+                chunks.append(response_chunk.message)
+
+        full_message = sum(chunks[1:], chunks[0])
+        yield self._get_agent_response(full_message)
+
+    def _get_agent_response(self, message: "ChatMessageContent") -> dict[str, Any]:
+        """Extracts the structured response from the agent's message content.
+        
+        Args:
+            message (ChatMessageContent): The message content from the agent.
+
+        Returns:
+            dict: A dictionary containing the content, task completion status, and user input requirement.
+        """
+        structured_response = ResponseFormat.model_validate_json(message.content)
+
+        default_response = {
+            "is_task_complete": False,
+            "require_user_input": True,
+            "content": "We are unable to process your request at the moment. Please try again.",
+        }
+
+        if isinstance(structured_response, ResponseFormat):
+            response_map = {
+                "input_required": {"is_task_complete": False, "require_user_input": True},
+                "error": {"is_task_complete": False, "require_user_input": True},
+                "completed": {"is_task_complete": True, "require_user_input": False},
+            }
+
+            response = response_map.get(structured_response.status)
+            if response:
+                return {**response, "content": structured_response.message}
+
+        return default_response
+    
+    async def _ensure_thread_exists(self, session_id: str) -> None:
+        """Ensure the thread exists for the given session ID.
+        
+        Args:
+            session_id (str): Unique identifier for the session.
+        """
+        # Replace check with self.thread.id when 
+        # https://github.com/microsoft/semantic-kernel/issues/11535 is fixed
+        if self.thread is None or self.thread._thread_id != session_id:
+            await self.thread.delete() if self.thread else None
+            self.thread = ChatHistoryAgentThread(thread_id=session_id)
+
+# endregion

--- a/samples/python/agents/semantickernel/pyproject.toml
+++ b/samples/python/agents/semantickernel/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "a2a-semantic-kernel"
+version = "0.1.0"
+description = "Leverage Semantic Kernel Agents using the A2A protocol."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "semantic-kernel>=1.28.0",
+    "a2a-samples",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.uv.sources]
+a2a-samples = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/samples/python/agents/semantickernel/task_manager.py
+++ b/samples/python/agents/semantickernel/task_manager.py
@@ -1,0 +1,207 @@
+import asyncio
+import logging
+from typing import AsyncIterable
+
+from common.server.task_manager import InMemoryTaskManager
+from common.types import (
+    Artifact,
+    InternalError,
+    InvalidParamsError,
+    JSONRPCResponse,
+    Message,
+    SendTaskRequest,
+    SendTaskResponse,
+    SendTaskStreamingRequest,
+    SendTaskStreamingResponse,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+from common.utils.push_notification_auth import PushNotificationSenderAuth
+
+from agents.semantickernel.agent import SemanticKernelTravelAgent
+
+logger = logging.getLogger(__name__)
+
+
+class TaskManager(InMemoryTaskManager):
+    """A TaskManager used for the Semantic Kernel Agent sample."""
+
+    def __init__(self, notification_sender_auth: PushNotificationSenderAuth):
+        """Initialize the TaskManager with a notification sender."""
+        super().__init__()
+        self.agent = SemanticKernelTravelAgent()
+        self.notification_sender_auth = notification_sender_auth
+
+    async def on_send_task(self, request: SendTaskRequest) -> SendTaskResponse:
+        """A method to handle a task request.
+        
+        Args:
+            request: The task request containing the parameters.
+
+        Returns:
+            SendTaskResponse: The response containing the task ID and status.
+        """
+        validation_error = self._validate_request(request)
+        if validation_error:
+            return SendTaskResponse(id=request.id, error=validation_error.error)
+
+        await self.upsert_task(request.params)
+        task = await self.update_store(request.params.id, TaskStatus(state=TaskState.WORKING), None)
+        await self.send_task_notification(task)
+
+        query = request.params.message.parts[0].text
+        try:
+            agent_response = await self.agent.invoke(query, request.params.sessionId)
+        except Exception as e:
+            logger.error(f"Semantic Kernel Task Manager error: {e}")
+            raise ValueError(f"Agent error: {e}")
+
+        return await self._process_agent_response(request, agent_response)
+
+    async def on_send_task_subscribe(
+        self, request: SendTaskStreamingRequest
+    ) -> AsyncIterable[SendTaskStreamingResponse] | JSONRPCResponse:
+        """A method to handle a task streaming request.
+        
+        Args:
+            request: The task streaming request containing the parameters.
+
+        Returns:
+            AsyncIterable[SendTaskStreamingResponse] | JSONRPCResponse: The streaming response or error.
+        """
+        try:
+            error = self._validate_request(request)
+            if error:
+                return error
+
+            await self.upsert_task(request.params)
+            sse_queue = await self.setup_sse_consumer(request.params.id, False)
+            asyncio.create_task(self._run_streaming_agent(request))
+            return self.dequeue_events_for_sse(request.id, request.params.id, sse_queue)
+        except Exception as e:
+            logger.error(f"Error in SSE stream: {e}")
+            return JSONRPCResponse(
+                id=request.id,
+                error=InternalError(message="Error in streaming response"),
+            )
+
+    async def _run_streaming_agent(self, request: SendTaskStreamingRequest) -> AsyncIterable[SendTaskStreamingResponse]:
+        """A method to run the streaming agent.
+        
+        Args:
+            request: The task streaming request containing the parameters.
+
+        Yields:
+            AsyncIterable[SendTaskStreamingResponse]: The streaming response.
+        """
+        try:
+            query = request.params.message.parts[0].text
+            async for partial in self.agent.stream(query, request.params.sessionId):
+                require_input = partial["require_user_input"]
+                is_done = partial["is_task_complete"]
+                text_content = partial["content"]
+                artifact = None
+
+                new_status = TaskStatus(state=TaskState.WORKING)
+                # By default, don't end the stream
+                final = False
+
+                if require_input:
+                    new_status.state = TaskState.INPUT_REQUIRED
+                    new_status.message = Message(
+                        role="agent",
+                        parts=[{"type": "text", "text": text_content}],
+                    )
+                    # End the stream if we need user input
+                    final = True
+                elif is_done:
+                    new_status.state = TaskState.COMPLETED
+                    artifact = Artifact(parts=[{"type": "text", "text": text_content}], index=0, append=False)
+                    # End the stream if the agent is fully done
+                    final = True
+                else:
+                    # Still "WORKING"
+                    new_status.message = Message(
+                        role="agent",
+                        parts=[{"type": "text", "text": text_content}],
+                    )
+
+                if artifact:
+                    task_artifact_update_event = TaskArtifactUpdateEvent(
+                        id=request.params.id, artifact=artifact
+                    )
+                    await self.enqueue_events_for_sse(
+                        request.params.id, task_artifact_update_event
+                    )
+
+                # Persist + notify
+                updated_task = await self.update_store(request.params.id, new_status, [artifact] if artifact else None)
+                await self.send_task_notification(updated_task)
+
+                await self.enqueue_events_for_sse(
+                    request.params.id,
+                    TaskStatusUpdateEvent(id=request.params.id, status=new_status, final=final),
+                )
+
+                if final:
+                    break
+
+        except Exception as e:
+            logger.error(f"Streaming agent encountered error: {e}")
+            await self.enqueue_events_for_sse(
+                request.params.id, InternalError(message=f"Error while streaming: {e}")
+            )
+
+    async def _process_agent_response(self, request: SendTaskRequest, agent_response: dict) -> SendTaskResponse:
+        """Process the agent's response and update the task status.
+        
+        Args:
+            request: The task request containing the parameters.
+            agent_response: The response from the agent.
+
+        Returns:
+            SendTaskResponse: The response containing the task ID and status.
+        """
+        parts = [{"type": "text", "text": agent_response["content"]}]
+        if agent_response["require_user_input"]:
+            task_status = TaskStatus(state=TaskState.INPUT_REQUIRED, message=Message(role="agent", parts=parts))
+        else:
+            task_status = TaskStatus(state=TaskState.COMPLETED)
+        artifact = Artifact(parts=parts) if not agent_response["require_user_input"] else None
+
+        updated_task = await self.update_store(request.params.id, task_status, [artifact] if artifact else None)
+        await self.send_task_notification(updated_task)
+        return SendTaskResponse(id=request.id, result=updated_task)
+
+    def _validate_request(self, request: SendTaskStreamingRequest) -> JSONRPCResponse | None:
+        """Validate the request parameters.
+        
+        Args:
+            request: The task request containing the parameters.
+
+        Returns:
+            JSONRPCResponse: The response containing the error if validation fails.
+        """
+        if not request.params.acceptedOutputModes:
+            return None
+        if not any(
+            mode in SemanticKernelTravelAgent.SUPPORTED_CONTENT_TYPES for mode in request.params.acceptedOutputModes
+        ):
+            logger.warning("Incompatible content type for SK Agent.")
+            return JSONRPCResponse(id=request.id, error=InvalidParamsError(message="Bad content type."))
+        return None
+
+    async def send_task_notification(self, task: SendTaskRequest) -> None:
+        """Send a push notification for the task.
+        
+        Args:
+            task: The task object containing the parameters.
+        """
+        if not await self.has_push_notification_info(task.id):
+            return
+        push_info = await self.get_push_notification_info(task.id)
+        await self.notification_sender_auth.send_push_notification(
+            push_info.url, data=task.model_dump(exclude_none=True)
+        )

--- a/samples/python/pyproject.toml
+++ b/samples/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 packages = ["common", "hosts"]
 
 [tool.uv.workspace]
-members = ["agents/crewai", "agents/ag2"]
+members = ["agents/crewai", "agents/ag2", "agents/semantickernel"]
 
 [build-system]
 requires = ["hatchling"]

--- a/samples/python/pyproject.toml
+++ b/samples/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 packages = ["common", "hosts"]
 
 [tool.uv.workspace]
-members = ["agents/crewai"]
+members = ["agents/crewai", "agents/ag2"]
 
 [build-system]
 requires = ["hatchling"]

--- a/samples/python/uv.lock
+++ b/samples/python/uv.lock
@@ -11,6 +11,7 @@ members = [
     "a2a-samples",
     "a2a-samples-image-gen",
     "a2a-samples-mcp",
+    "a2a-semantic-kernel",
 ]
 
 [[package]]
@@ -88,6 +89,7 @@ requires-dist = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "a2a-samples-mcp"
 version = "0.1.0"
 source = { virtual = "agents/ag2" }
@@ -95,11 +97,20 @@ dependencies = [
     { name = "a2a-samples" },
     { name = "ag2", extra = ["mcp", "openai"] },
     { name = "google-genai" },
+=======
+name = "a2a-semantic-kernel"
+version = "0.1.0"
+source = { editable = "agents/semantickernel" }
+dependencies = [
+    { name = "a2a-samples" },
+    { name = "semantic-kernel" },
+>>>>>>> upstream/main
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "a2a-samples", editable = "." },
+<<<<<<< HEAD
     { name = "ag2", specifier = ">=0.8.6" },
     { name = "ag2", extras = ["mcp", "openai"], specifier = ">=0.8.6" },
     { name = "google-genai", specifier = ">=1.10.0" },
@@ -123,6 +134,9 @@ mcp = [
 ]
 openai = [
     { name = "pyautogen", extra = ["openai"] },
+=======
+    { name = "semantic-kernel", specifier = ">=1.28.0" },
+>>>>>>> upstream/main
 ]
 
 [[package]]
@@ -181,6 +195,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a7/d0de521dc5ca6e8c766f8d1f373c859925f10b2a96455b16107c1e9b2d60/aiohttp-3.11.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2b86efe23684b58a88e530c4ab5b20145f102916bbb2d82942cafec7bd36a647", size = 1673682 },
     { url = "https://files.pythonhosted.org/packages/f0/86/5c075ebeca7063a49a0da65a4e0aa9e49d741aca9a2fe9552d86906e159b/aiohttp-3.11.14-cp313-cp313-win32.whl", hash = "sha256:b9c60d1de973ca94af02053d9b5111c4fbf97158e139b14f1be68337be267be6", size = 411014 },
     { url = "https://files.pythonhosted.org/packages/4a/e0/2f9e77ef2d4a1dbf05f40b7edf1e1ce9be72bdbe6037cf1db1712b455e3e/aiohttp-3.11.14-cp313-cp313-win_amd64.whl", hash = "sha256:0a29be28e60e5610d2437b5b2fed61d6f3dcde898b57fb048aa5079271e7f6f3", size = 436964 },
+]
+
+[[package]]
+name = "aioice"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/a2/45dfab1d5a7f96c48595a5770379acf406cdf02a2cd1ac1729b599322b08/aioice-0.10.1.tar.gz", hash = "sha256:5c8e1422103448d171925c678fb39795e5fe13d79108bebb00aa75a899c2094a", size = 44304 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/58/af07dda649c22a1ae954ffb7aaaf4d4a57f1bf00ebdf62307affc0b8552f/aioice-0.10.1-py3-none-any.whl", hash = "sha256:f31ae2abc8608b1283ed5f21aebd7b6bd472b152ff9551e9b559b2d8efed79e9", size = 24872 },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cffi" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/60/7bb59c28c6e65e5d74258d392f531f555f12ab519b0f467ffd6b76650c20/aiortc-1.11.0.tar.gz", hash = "sha256:50b9d86f6cba87d95ce7c6b051949208b48f8062b231837aed8f049045f11a28", size = 1179206 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/34/5c34707ce58ca0fd3b157a3b478255a8445950bf2b87f048864eb7233f5f/aiortc-1.11.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:018b0d623c6b88b9cd4bd3b700dece943731d081c50fef1b866a43f6b46a7343", size = 1218501 },
+    { url = "https://files.pythonhosted.org/packages/1b/d7/cc1d483097f2ae605e07e9f7af004c473da5756af25149823de2047eb991/aiortc-1.11.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd6477ac9227e9fd80ca079d6614b5b0b45c1887f214e67cddc7fde2692d95", size = 898901 },
+    { url = "https://files.pythonhosted.org/packages/00/64/caf7e7b3c49d492ba79256638644812d66ca68dcfa8e27307fd58f564555/aiortc-1.11.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc311672d25091061eaa9c3fe1adbb7f2ef677c6fabd2cffdff8c724c1f81ce7", size = 1750429 },
+    { url = "https://files.pythonhosted.org/packages/11/12/3e37c16de90ead788e45bfe10fe6fea66711919d2bf3826f663779824de0/aiortc-1.11.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f57c5804135d357291f25de65faf7a844d7595c6eb12493e0a304f4d5c34d660", size = 1867914 },
+    { url = "https://files.pythonhosted.org/packages/aa/a9/f0a32b3966e8bc8cf4faea558b6e40171eacfc04b14e8b077bebc6ec57e3/aiortc-1.11.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43ff9f5c2a5d657fbb4ab8c9b4e4c9d2967753e03c4539eb1dd82014816ef6a0", size = 1893742 },
+    { url = "https://files.pythonhosted.org/packages/a5/c5/57f997af08ceca5e78a5f23e4cb93445236eff39af0c9940495ae7069de4/aiortc-1.11.0-cp39-abi3-win32.whl", hash = "sha256:5e10a50ca6df3abc32811e1c84fe131b7d20d3e5349f521ca430683ca9a96c70", size = 923160 },
+    { url = "https://files.pythonhosted.org/packages/b2/ce/7f969694b950f673d7bf5ec697608366bd585ff741760e107e3eff55b131/aiortc-1.11.0-cp39-abi3-win_amd64.whl", hash = "sha256:67debf5ce89fb12c64b4be24e70809b29f1bb0e635914760d0c2e1193955ff62", size = 1009541 },
 ]
 
 [[package]]
@@ -348,6 +400,31 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "14.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/ff/092b5bba046a9fd7324d9eee498683ee9e410715d21eff9d3db92dd14910/av-14.3.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:8250680e4e17c404008005b60937248712e9c621689bbc647577d8e2eaa00a66", size = 20004033 },
+    { url = "https://files.pythonhosted.org/packages/90/b8/fa4fb7d5f1c6299c2f691d527c47a717155acb9ff9f3c30358d7d50d60e1/av-14.3.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:349aa6ef529daaede95f37e9825c6e36fddb15906b27938d9e22dcdca2e1f648", size = 23804484 },
+    { url = "https://files.pythonhosted.org/packages/79/f3/230b2d05a918ed4f9390f8d7ca766250662e6200d77453852e85cd854291/av-14.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f953a9c999add37b953cb3ad4ef3744d3d4eee50ef1ffeb10cb1f2e6e2cbc088", size = 33727815 },
+    { url = "https://files.pythonhosted.org/packages/95/f8/593ab784116356e8eb00e1f1b3ab2383c59c1ef40d6bcf19be7cb4679237/av-14.3.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1eaefb47d2ee178adfcedb9a70678b1a340a6670262d06ffa476da9c7d315aef", size = 32307276 },
+    { url = "https://files.pythonhosted.org/packages/40/ff/2237657852dac32052b7401da6bc7fc23127dc7a1ccbb23d4c640c8ea95b/av-14.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e3b7ca97af1eb3e41e7971a0eb75c1375f73b89ff54afb6d8bf431107160855", size = 35439982 },
+    { url = "https://files.pythonhosted.org/packages/01/f7/e4561cabd16e96a482609211eb8d260a720f222e28bdd80e3af0bbc560a6/av-14.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e2a0404ac4bfa984528538fb7edeb4793091a5cc6883a473d13cb82c505b62e0", size = 36366758 },
+    { url = "https://files.pythonhosted.org/packages/ce/ee/7334ca271b71c394ef400a11b54b1d8d3eb28a40681b37c3a022d9dc59c8/av-14.3.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2ceb45e998184231bcc99a14f91f4265d959e6b804fe9054728e9855214b2ad5", size = 34643022 },
+    { url = "https://files.pythonhosted.org/packages/db/4f/c692ee808a68aa2ec634a00ce084d3f68f28ab6ab7a847780974d780762d/av-14.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f87df669f49d5202f3933dc94e606353f5c5f9a709a1c0823b3f6d6333560bd7", size = 37448043 },
+    { url = "https://files.pythonhosted.org/packages/84/7d/ed088731274746667e18951cc51d4e054bec941898b853e211df84d47745/av-14.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:90ef006bc334fff31d5e839368bcd8c6345959749a980ce6f7a8a5fa2c8396e7", size = 27460903 },
+    { url = "https://files.pythonhosted.org/packages/e0/a0/d9bd6fea6b87ed15294eb2c5da5968e842a062b44e5e190d8cb7be26c333/av-14.3.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:0ec9ed764acbbcc590f30891abdb792c2917e13c91c407751f01ff3d2f957672", size = 19966774 },
+    { url = "https://files.pythonhosted.org/packages/40/92/69d2e596be108b47b83d115ab697f25f553a5449974de6ce4d1b37d313f9/av-14.3.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5c886dcbc7d2f6b6c88e0bea061b268895265d1ec8593e1fd2c69c9795225b9d", size = 23768305 },
+    { url = "https://files.pythonhosted.org/packages/14/34/db18546592b5dffaa8066d3129001fe669a0340be7c324792c4bfae356c0/av-14.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acfd2f6d66b3587131060cba58c007028784ba26d1615d43e0d4afdc37d5945a", size = 33424931 },
+    { url = "https://files.pythonhosted.org/packages/4d/6a/eef972ffae9b7e7edf2606b153cf210cb721fdf777e53790a5b0f19b85c2/av-14.3.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee262ea4bf016a3e48ce75716ca23adef89cf0d7a55618423fe63bc5986ac2", size = 32018105 },
+    { url = "https://files.pythonhosted.org/packages/60/9a/8eb6940d78a6d0b695719db3922dec4f3994ca1a0dc943db47720ca64d8f/av-14.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d68e5dd7a1b7373bbdbd82fa85b97d5aed4441d145c3938ba1fe3d78637bb05", size = 35148084 },
+    { url = "https://files.pythonhosted.org/packages/19/63/fe614c11f43e06c6e04680a53ecd6252c6c074104c2c179ec7d47cc12a82/av-14.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dd2d8fc3d514305fa979363298bf600fa7f48abfb827baa9baf1a49520291a62", size = 36089398 },
+    { url = "https://files.pythonhosted.org/packages/d0/d6/8cc3c644364199e564e0642674f68b0aeebedc18b6877460c22f7484f3ab/av-14.3.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:96d19099b3867fac67dfe2bb29fd15ef41f1f508d2ec711d1f081e505a9a8d04", size = 34356871 },
+    { url = "https://files.pythonhosted.org/packages/27/85/6327062a5bb61f96411c0f444a995dc6a7bf2d7189d9c896aa03b4e46028/av-14.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:15dc4a7c916620b733613661ceb7a186f141a0fc98608dfbafacdc794a7cd665", size = 37174375 },
+    { url = "https://files.pythonhosted.org/packages/5b/c0/44232f2e04358ecce33a1d9354f95683bb24262a788d008d8c9dafa3622d/av-14.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:f930faa2e6f6a46d55bc67545b81f5b22bd52975679c1de0f871fc9f8ca95711", size = 27433259 },
+]
+
+[[package]]
 name = "azure-common"
 version = "1.1.28"
 source = { registry = "https://pypi.org/simple" }
@@ -368,6 +445,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/ee/668328306a9e963a5ad9f152cd98c7adad86c822729fd1d2a01613ad1e67/azure_core-1.32.0.tar.gz", hash = "sha256:22b3c35d6b2dae14990f6c1be2912bf23ffe50b220e708a28ab1bb92b1c730e5", size = 279128 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/83/325bf5e02504dbd8b4faa98197a44cdf8a325ef259b48326a2b6f17f8383/azure_core-1.32.0-py3-none-any.whl", hash = "sha256:eac191a0efb23bfa83fddf321b27b122b4ec847befa3091fa736a5c32c50d7b4", size = 198855 },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a1/f1a683672e7a88ea0e3119f57b6c7843ed52650fdcac8bfa66ed84e86e40/azure_identity-1.21.0.tar.gz", hash = "sha256:ea22ce6e6b0f429bc1b8d9212d5b9f9877bd4c82f1724bfa910760612c07a9a6", size = 266445 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9f/1f9f3ef4f49729ee207a712a5971a9ca747f2ca47d9cbf13cf6953e3478a/azure_identity-1.21.0-py3-none-any.whl", hash = "sha256:258ea6325537352440f71b35c3dffe9d240eae4a5126c1b7ce5efd5766bd9fd9", size = 189190 },
 ]
 
 [[package]]
@@ -532,6 +625,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -630,6 +732,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
+name = "cloudevents"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/41/97a7448adf5888d394a22d491749fb55b1e06e95870bd9edc3d58889bb8a/cloudevents-1.11.0.tar.gz", hash = "sha256:5be990583e99f3b08af5a709460e20b25cb169270227957a20b47a6ec8635e66", size = 33670 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/0e/268a75b712e4dd504cff19e4b987942cd93532d1680009d6492c9d41bdac/cloudevents-1.11.0-py3-none-any.whl", hash = "sha256:77edb4f2b01f405c44ea77120c3213418dbc63d8859f98e9e85de875502b8a76", size = 55088 },
 ]
 
 [[package]]
@@ -791,6 +905,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -830,6 +953,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
 ]
 
 [[package]]
@@ -1674,6 +1806,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314 },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1887,6 +2028,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462 },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/58/3485da8cb93d2f393bce453adeef16896751f14ba3e2024bc21dc9597646/jsonschema_path-0.3.4-py3-none-any.whl", hash = "sha256:f502191fdc2b22050f9a81c9237be9d27145b9001c55842bece5e94e382e52f8", size = 14810 },
 ]
 
 [[package]]
@@ -2161,6 +2317,22 @@ wheels = [
 ]
 
 [[package]]
+name = "lazy-object-proxy"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/f0/f02e2d150d581a294efded4020094a371bbab42423fe78625ac18854d89b/lazy-object-proxy-1.10.0.tar.gz", hash = "sha256:78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69", size = 43271 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/5d/768a7f2ccebb29604def61842fd54f6f5f75c79e366ee8748dda84de0b13/lazy_object_proxy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e98c8af98d5707dcdecc9ab0863c0ea6e88545d42ca7c3feffb6b4d1e370c7ba", size = 27560 },
+    { url = "https://files.pythonhosted.org/packages/b3/ce/f369815549dbfa4bebed541fa4e1561d69e4f268a1f6f77da886df182dab/lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:952c81d415b9b80ea261d2372d2a4a2332a3890c2b83e0535f263ddfe43f0d43", size = 72403 },
+    { url = "https://files.pythonhosted.org/packages/44/46/3771e0a4315044aa7b67da892b2fb1f59dfcf0eaff2c8967b2a0a85d5896/lazy_object_proxy-1.10.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80b39d3a151309efc8cc48675918891b865bdf742a8616a337cb0090791a0de9", size = 72401 },
+    { url = "https://files.pythonhosted.org/packages/81/39/84ce4740718e1c700bd04d3457ac92b2e9ce76529911583e7a2bf4d96eb2/lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e221060b701e2aa2ea991542900dd13907a5c90fa80e199dbf5a03359019e7a3", size = 75375 },
+    { url = "https://files.pythonhosted.org/packages/86/3b/d6b65da2b864822324745c0a73fe7fd86c67ccea54173682c3081d7adea8/lazy_object_proxy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:92f09ff65ecff3108e56526f9e2481b8116c0b9e1425325e13245abfd79bdb1b", size = 75466 },
+    { url = "https://files.pythonhosted.org/packages/f5/33/467a093bf004a70022cb410c590d937134bba2faa17bf9dc42a48f49af35/lazy_object_proxy-1.10.0-cp312-cp312-win32.whl", hash = "sha256:3ad54b9ddbe20ae9f7c1b29e52f123120772b06dbb18ec6be9101369d63a4074", size = 25914 },
+    { url = "https://files.pythonhosted.org/packages/77/ce/7956dc5ac2f8b62291b798c8363c81810e22a9effe469629d297d087e350/lazy_object_proxy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:127a789c75151db6af398b8972178afe6bda7d6f68730c057fbbc2e96b08d282", size = 27525 },
+    { url = "https://files.pythonhosted.org/packages/31/8b/94dc8d58704ab87b39faed6f2fc0090b9d90e2e2aa2bbec35c79f3d2a054/lazy_object_proxy-1.10.0-pp310.pp311.pp312.pp38.pp39-none-any.whl", hash = "sha256:80fa48bd89c8f2f456fc0765c11c23bf5af827febacd2f523ca5bc1893fcc09d", size = 16405 },
+]
+
+[[package]]
 name = "litellm"
 version = "1.65.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2365,12 +2537,47 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3b/7fa1fe835e2e93fd6d7b52b2f95ae810cf5ba133e1845f726f5a992d62c2/more-itertools-10.6.0.tar.gz", hash = "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b", size = 125009 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/62/0fe302c6d1be1c777cab0616e6302478251dfbf9055ad426f5d0def75c89/more_itertools-10.6.0-py3-none-any.whl", hash = "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89", size = 63038 },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
+]
+
+[[package]]
+name = "msal"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/5f/ef42ef25fba682e83a8ee326a1a788e60c25affb58d014495349e37bce50/msal-1.32.0.tar.gz", hash = "sha256:5445fe3af1da6be484991a7ab32eaa82461dc2347de105b76af92c610c3335c2", size = 149817 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/5a/2e663ef56a5d89eba962941b267ebe5be8c5ea340a9929d286e2f5fac505/msal-1.32.0-py3-none-any.whl", hash = "sha256:9dbac5384a10bbbf4dae5c7ea0d707d14e087b92c5aa4954b3feaa2d1aa0bcb7", size = 114655 },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583 },
 ]
 
 [[package]]
@@ -2473,6 +2680,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c1/e5/aa97891440bf6bc4239e9b918d89fea58eb87dff1d8d14a69b45ef677e66/narwhals-1.32.0.tar.gz", hash = "sha256:bd0aa41434737adb4b26f8593f3559abc7d938730ece010fe727b58bc363580d", size = 258915 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/96/79a6168dc7a5098066e097c01a45d01608c8df6552dfb92a2676ce623186/narwhals-1.32.0-py3-none-any.whl", hash = "sha256:8bdbf3f76155887412eea04b0b06303856ac1aa3d9e8bda5b5e54612855fa560", size = 320073 },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195 },
 ]
 
 [[package]]
@@ -2582,6 +2798,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/f5/ae0f3cd226c2993b4ac1cc4b5f6ca099764689f403c14922c9356accec66/openai-1.70.0.tar.gz", hash = "sha256:e52a8d54c3efeb08cf58539b5b21a5abef25368b5432965e4de88cdf4e091b2b", size = 409640 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/39/c4b38317d2c702c4bc763957735aaeaf30dfc43b5b824121c49a4ba7ba0f/openai-1.70.0-py3-none-any.whl", hash = "sha256:f6438d053fd8b2e05fd6bef70871e832d9bbdf55e119d0ac5b92726f1ae6f614", size = 599070 },
+]
+
+[[package]]
+name = "openapi-core"
+version = "0.19.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "more-itertools" },
+    { name = "openapi-schema-validator" },
+    { name = "openapi-spec-validator" },
+    { name = "parse" },
+    { name = "typing-extensions" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/35/1acaa5f2fcc6e54eded34a2ec74b479439c4e469fc4e8d0e803fda0234db/openapi_core-0.19.5.tar.gz", hash = "sha256:421e753da56c391704454e66afe4803a290108590ac8fa6f4a4487f4ec11f2d3", size = 103264 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6f/83ead0e2e30a90445ee4fc0135f43741aebc30cca5b43f20968b603e30b6/openapi_core-0.19.5-py3-none-any.whl", hash = "sha256:ef7210e83a59394f46ce282639d8d26ad6fc8094aa904c9c16eb1bac8908911f", size = 106595 },
+]
+
+[[package]]
+name = "openapi-schema-validator"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755 },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/fe/21954ff978239dc29ebb313f5c87eeb4ec929b694b9667323086730998e2/openapi_spec_validator-0.7.1.tar.gz", hash = "sha256:8577b85a8268685da6f8aa30990b83b7960d4d1117e901d451b5d572605e5ec7", size = 37985 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/4d/e744fff95aaf3aeafc968d5ba7297c8cda0d1ecb8e3acd21b25adae4d835/openapi_spec_validator-0.7.1-py3-none-any.whl", hash = "sha256:3c81825043f24ccbcd2f4b149b11e8231abce5ba84f37065e14ec947d8f4e959", size = 38998 },
 ]
 
 [[package]]
@@ -2869,12 +3134,30 @@ wheels = [
 ]
 
 [[package]]
+name = "parse"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126 },
+]
+
+[[package]]
 name = "parso"
 version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
+]
+
+[[package]]
+name = "pathable"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592 },
 ]
 
 [[package]]
@@ -2990,6 +3273,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/dd/30f7d2e992f80fcaedc5b99761e006bbb0b954813243542c480b9576b4be/posthog-3.23.0.tar.gz", hash = "sha256:1ac0305ab6c54a80c4a82c137231f17616bef007bbf474d1a529cda032d808eb", size = 72077 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/1e/aa457f5b15c9a018434dd71567c4a8f09c1701607a1d4daf5f01d6eccb7a/posthog-3.23.0-py2.py3-none-any.whl", hash = "sha256:2b07d06670170ac2e21465dffa8d356722834cc877ab34e583da6e525c1037df", size = 84976 },
+]
+
+[[package]]
+name = "prance"
+version = "23.6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "ruamel-yaml" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/f0/bcb5ffc8b7ab8e3d02dbef3bd945cf8fd6e12c146774f900659406b9fce1/prance-23.6.21.0.tar.gz", hash = "sha256:d8c15f8ac34019751cc4945f866d8d964d7888016d10de3592e339567177cabe", size = 2798776 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/db/4fb4901ee61274d0ab97746461fc5f2637e5d73aa73f34ee28e941a699a1/prance-23.6.21.0-py3-none-any.whl", hash = "sha256:6a4276fa07ed9f22feda4331097d7503c4adc3097e46ffae97425f2c1026bd9f", size = 36279 },
 ]
 
 [[package]]
@@ -3186,6 +3485,7 @@ wheels = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "pyautogen"
 version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3213,6 +3513,15 @@ mcp = [
 openai = [
     { name = "openai" },
 ]
+=======
+name = "pybars4"
+version = "0.9.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymeta3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/52/9aa428633ef5aba4b096b2b2f8d046ece613cecab28b4ceed54126d25ea5/pybars4-0.9.13.tar.gz", hash = "sha256:425817da20d4ad320bc9b8e77a60cab1bb9d3c677df3dce224925c3310fcd635", size = 29907 }
+>>>>>>> upstream/main
 
 [[package]]
 name = "pycparser"
@@ -3303,6 +3612,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3318,6 +3639,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997 },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pylibsrtp"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/c8/a59e61f5dd655f5f21033bd643dd31fe980a537ed6f373cdfb49d3a3bd32/pylibsrtp-0.12.0.tar.gz", hash = "sha256:f5c3c0fb6954e7bb74dc7e6398352740ca67327e6759a199fe852dbc7b84b8ac", size = 10878 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f0/b818395c4cae2d5cc5a0c78fc47d694eae78e6a0d678baeb52a381a26327/pylibsrtp-0.12.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5adde3cf9a5feef561d0eb7ed99dedb30b9bf1ce9a0c1770b2bf19fd0b98bc9a", size = 1727918 },
+    { url = "https://files.pythonhosted.org/packages/05/1a/ee553abe4431b7bd9bab18f078c0ad2298b94ea55e664da6ecb8700b1052/pylibsrtp-0.12.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d2c81d152606721331ece87c80ed17159ba6da55c7c61a6b750cff67ab7f63a5", size = 2057900 },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/2dd0188be58d3cba48c5eb4b3c787e5743c111cd0c9289de4b6f2798382a/pylibsrtp-0.12.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:242fa3d44219846bf1734d5df595563a2c8fbb0fb00ccc79ab0f569fc0af2c1b", size = 2567047 },
+    { url = "https://files.pythonhosted.org/packages/6c/3a/4bdab9fc1d78f2efa02c8a8f3e9c187bfa278e89481b5123f07c8dd69310/pylibsrtp-0.12.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b74aaf8fac1b119a3c762f54751c3d20e77227b84c26d85aae57c2c43129b49c", size = 2168775 },
+    { url = "https://files.pythonhosted.org/packages/d0/fc/0b1e1bfed420d79427d50aff84c370dcd78d81af9500c1e86fbcc5bf95e1/pylibsrtp-0.12.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e3e223102989b71f07e1deeb804170ed53fb4e1b283762eb031bd45bb425d4", size = 2225033 },
+    { url = "https://files.pythonhosted.org/packages/39/7b/e1021d27900315c2c077ec7d45f50274cedbdde067ff679d44df06f01a8a/pylibsrtp-0.12.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:36d07de64dbc82dbbb99fd77f36c8e23d6730bdbcccf09701945690a9a9a422a", size = 2606093 },
+    { url = "https://files.pythonhosted.org/packages/eb/c2/0fae6687a06fcde210a778148ec808af49e431c36fe9908503a695c35479/pylibsrtp-0.12.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:ef03b4578577690f716fd023daed8914eee6de9a764fa128eda19a0e645cc032", size = 2193213 },
+    { url = "https://files.pythonhosted.org/packages/67/c2/2ed7a4a5c38b999fd34298f76b93d29f5ba8c06f85cfad3efd9468343715/pylibsrtp-0.12.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0a8421e9fe4d20ce48d439430e55149f12b1bca1b0436741972c362c49948c0a", size = 2256774 },
+    { url = "https://files.pythonhosted.org/packages/48/d7/f13fedce3b21d24f6f154d1dee7287464a34728dcb3b0c50f687dbad5765/pylibsrtp-0.12.0-cp39-abi3-win32.whl", hash = "sha256:cbc9bfbfb2597e993a1aa16b832ba16a9dd4647f70815421bb78484f8b50b924", size = 1156186 },
+    { url = "https://files.pythonhosted.org/packages/9b/26/3a20b638a3a3995368f856eeb10701dd6c0e9ace9fb6665eeb1b95ccce19/pylibsrtp-0.12.0-cp39-abi3-win_amd64.whl", hash = "sha256:061ef1dbb5f08079ac6d7515b7e67ca48a3163e16e5b820beea6b01cb31d7e54", size = 1485072 },
+]
+
+[[package]]
+name = "pymeta3"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/af/409edba35fc597f1e386e3860303791ab5a28d6cc9a8aecbc567051b19a9/PyMeta3-0.5.1.tar.gz", hash = "sha256:18bda326d9a9bbf587bfc0ee0bc96864964d78b067288bcf55d4d98681d05bcb", size = 29566 }
+
+[[package]]
+name = "pyopenssl"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/26/e25b4a374b4639e0c235527bbe31c0524f26eda701d79456a7e1877f4cc5/pyopenssl-25.0.0.tar.gz", hash = "sha256:cd2cef799efa3936bb08e8ccb9433a575722b9dd986023f1cabc4ae64e9dac16", size = 179573 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/d7/eb76863d2060dcbe7c7e6cccfd95ac02ea0b9acc37745a0d99ff6457aefb/pyOpenSSL-25.0.0-py3-none-any.whl", hash = "sha256:424c247065e46e76a37411b9ab1782541c23bb658bf003772c3405fbaa128e90", size = 56453 },
 ]
 
 [[package]]
@@ -3633,6 +3999,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490 },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3705,6 +4083,44 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.18.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.13' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/46/f44d8be06b85bc7c4d8c95d658be2b68f27711f279bf9dd0612a5e4794f5/ruamel.yaml-0.18.10.tar.gz", hash = "sha256:20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58", size = 143447 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/36/dfc1ebc0081e6d39924a2cc53654497f967a084a436bb64402dfce4254d9/ruamel.yaml-0.18.10-py3-none-any.whl", hash = "sha256:30f22513ab2301b3d2b577adc121c6471f28734d3d9728581245f1e76468b4f1", size = 117729 },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f", size = 225315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433 },
+    { url = "https://files.pythonhosted.org/packages/ec/b0/b850385604334c2ce90e3ee1013bd911aedf058a934905863a6ea95e9eb4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:943f32bc9dedb3abff9879edc134901df92cfce2c3d5c9348f172f62eb2d771d", size = 647362 },
+    { url = "https://files.pythonhosted.org/packages/44/d0/3f68a86e006448fb6c005aee66565b9eb89014a70c491d70c08de597f8e4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c3829bb364fdb8e0332c9931ecf57d9be3519241323c5274bd82f709cebc0c", size = 754118 },
+    { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497 },
+    { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042 },
+    { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831 },
+    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692 },
+    { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777 },
+    { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523 },
+    { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011 },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/212f473a93ae78c669ffa0cb051e3fee1139cb2d385d2ae1653d64281507/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475", size = 642488 },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/ecfbe2123ade605c49ef769788f79c38ddb1c8fa81e01f4dbf5cf1a44b16/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef", size = 745066 },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785 },
+    { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017 },
+    { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270 },
+    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059 },
+    { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583 },
+    { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3736,6 +4152,73 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/01/0ea2e66bad2f13271e93b729c653747614784d3ebde219679e41ccdceecd/schema-0.7.7.tar.gz", hash = "sha256:7da553abd2958a19dc2547c388cde53398b39196175a9be59ea1caf5ab0a1807", size = 44245 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/1b/81855a88c6db2b114d5b2e9f96339190d5ee4d1b981d217fa32127bb00e0/schema-0.7.7-py2.py3-none-any.whl", hash = "sha256:5d976a5b50f36e74e2157b47097b60002bd4d42e65425fcc9c9befadb4255dde", size = 18632 },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/b9/31ba9cd990e626574baf93fbc1ac61cf9ed54faafd04c479117517661637/scipy-1.15.2.tar.gz", hash = "sha256:cd58a314d92838f7e6f755c8a2167ead4f27e1fd5c1251fd54289569ef3495ec", size = 59417316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/5d/3c78815cbab499610f26b5bae6aed33e227225a9fa5290008a733a64f6fc/scipy-1.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c4697a10da8f8765bb7c83e24a470da5797e37041edfd77fd95ba3811a47c4fd", size = 38756184 },
+    { url = "https://files.pythonhosted.org/packages/37/20/3d04eb066b471b6e171827548b9ddb3c21c6bbea72a4d84fc5989933910b/scipy-1.15.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:869269b767d5ee7ea6991ed7e22b3ca1f22de73ab9a49c44bad338b725603301", size = 30163558 },
+    { url = "https://files.pythonhosted.org/packages/a4/98/e5c964526c929ef1f795d4c343b2ff98634ad2051bd2bbadfef9e772e413/scipy-1.15.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:bad78d580270a4d32470563ea86c6590b465cb98f83d760ff5b0990cb5518a93", size = 22437211 },
+    { url = "https://files.pythonhosted.org/packages/1d/cd/1dc7371e29195ecbf5222f9afeedb210e0a75057d8afbd942aa6cf8c8eca/scipy-1.15.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:b09ae80010f52efddb15551025f9016c910296cf70adbf03ce2a8704f3a5ad20", size = 25232260 },
+    { url = "https://files.pythonhosted.org/packages/f0/24/1a181a9e5050090e0b5138c5f496fee33293c342b788d02586bc410c6477/scipy-1.15.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a6fd6eac1ce74a9f77a7fc724080d507c5812d61e72bd5e4c489b042455865e", size = 35198095 },
+    { url = "https://files.pythonhosted.org/packages/c0/53/eaada1a414c026673eb983f8b4a55fe5eb172725d33d62c1b21f63ff6ca4/scipy-1.15.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b871df1fe1a3ba85d90e22742b93584f8d2b8e6124f8372ab15c71b73e428b8", size = 37297371 },
+    { url = "https://files.pythonhosted.org/packages/e9/06/0449b744892ed22b7e7b9a1994a866e64895363572677a316a9042af1fe5/scipy-1.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:03205d57a28e18dfd39f0377d5002725bf1f19a46f444108c29bdb246b6c8a11", size = 36872390 },
+    { url = "https://files.pythonhosted.org/packages/6a/6f/a8ac3cfd9505ec695c1bc35edc034d13afbd2fc1882a7c6b473e280397bb/scipy-1.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:601881dfb761311045b03114c5fe718a12634e5608c3b403737ae463c9885d53", size = 39700276 },
+    { url = "https://files.pythonhosted.org/packages/f5/6f/e6e5aff77ea2a48dd96808bb51d7450875af154ee7cbe72188afb0b37929/scipy-1.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:e7c68b6a43259ba0aab737237876e5c2c549a031ddb7abc28c7b47f22e202ded", size = 40942317 },
+    { url = "https://files.pythonhosted.org/packages/53/40/09319f6e0f276ea2754196185f95cd191cb852288440ce035d5c3a931ea2/scipy-1.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:01edfac9f0798ad6b46d9c4c9ca0e0ad23dbf0b1eb70e96adb9fa7f525eff0bf", size = 38717587 },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/2854f40ecd19585d65afaef601e5e1f8dbf6758b2f95b5ea93d38655a2c6/scipy-1.15.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:08b57a9336b8e79b305a143c3655cc5bdbe6d5ece3378578888d2afbb51c4e37", size = 30100266 },
+    { url = "https://files.pythonhosted.org/packages/dd/b1/f9fe6e3c828cb5930b5fe74cb479de5f3d66d682fa8adb77249acaf545b8/scipy-1.15.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:54c462098484e7466362a9f1672d20888f724911a74c22ae35b61f9c5919183d", size = 22373768 },
+    { url = "https://files.pythonhosted.org/packages/15/9d/a60db8c795700414c3f681908a2b911e031e024d93214f2d23c6dae174ab/scipy-1.15.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:cf72ff559a53a6a6d77bd8eefd12a17995ffa44ad86c77a5df96f533d4e6c6bb", size = 25154719 },
+    { url = "https://files.pythonhosted.org/packages/37/3b/9bda92a85cd93f19f9ed90ade84aa1e51657e29988317fabdd44544f1dd4/scipy-1.15.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9de9d1416b3d9e7df9923ab23cd2fe714244af10b763975bea9e4f2e81cebd27", size = 35163195 },
+    { url = "https://files.pythonhosted.org/packages/03/5a/fc34bf1aa14dc7c0e701691fa8685f3faec80e57d816615e3625f28feb43/scipy-1.15.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb530e4794fc8ea76a4a21ccb67dea33e5e0e60f07fc38a49e821e1eae3b71a0", size = 37255404 },
+    { url = "https://files.pythonhosted.org/packages/4a/71/472eac45440cee134c8a180dbe4c01b3ec247e0338b7c759e6cd71f199a7/scipy-1.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5ea7ed46d437fc52350b028b1d44e002646e28f3e8ddc714011aaf87330f2f32", size = 36860011 },
+    { url = "https://files.pythonhosted.org/packages/01/b3/21f890f4f42daf20e4d3aaa18182dddb9192771cd47445aaae2e318f6738/scipy-1.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:11e7ad32cf184b74380f43d3c0a706f49358b904fa7d5345f16ddf993609184d", size = 39657406 },
+    { url = "https://files.pythonhosted.org/packages/0d/76/77cf2ac1f2a9cc00c073d49e1e16244e389dd88e2490c91d84e1e3e4d126/scipy-1.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:a5080a79dfb9b78b768cebf3c9dcbc7b665c5875793569f48bf0e2b1d7f68f6f", size = 40961243 },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/a57f8ddcf48e129e6054fa9899a2a86d1fc6b07a0e15c7eebff7ca94533f/scipy-1.15.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:447ce30cee6a9d5d1379087c9e474628dab3db4a67484be1b7dc3196bfb2fac9", size = 38870286 },
+    { url = "https://files.pythonhosted.org/packages/0c/43/c304d69a56c91ad5f188c0714f6a97b9c1fed93128c691148621274a3a68/scipy-1.15.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:c90ebe8aaa4397eaefa8455a8182b164a6cc1d59ad53f79943f266d99f68687f", size = 30141634 },
+    { url = "https://files.pythonhosted.org/packages/44/1a/6c21b45d2548eb73be9b9bff421aaaa7e85e22c1f9b3bc44b23485dfce0a/scipy-1.15.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:def751dd08243934c884a3221156d63e15234a3155cf25978b0a668409d45eb6", size = 22415179 },
+    { url = "https://files.pythonhosted.org/packages/74/4b/aefac4bba80ef815b64f55da06f62f92be5d03b467f2ce3668071799429a/scipy-1.15.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:302093e7dfb120e55515936cb55618ee0b895f8bcaf18ff81eca086c17bd80af", size = 25126412 },
+    { url = "https://files.pythonhosted.org/packages/b1/53/1cbb148e6e8f1660aacd9f0a9dfa2b05e9ff1cb54b4386fe868477972ac2/scipy-1.15.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7cd5b77413e1855351cdde594eca99c1f4a588c2d63711388b6a1f1c01f62274", size = 34952867 },
+    { url = "https://files.pythonhosted.org/packages/2c/23/e0eb7f31a9c13cf2dca083828b97992dd22f8184c6ce4fec5deec0c81fcf/scipy-1.15.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d0194c37037707b2afa7a2f2a924cf7bac3dc292d51b6a925e5fcb89bc5c776", size = 36890009 },
+    { url = "https://files.pythonhosted.org/packages/03/f3/e699e19cabe96bbac5189c04aaa970718f0105cff03d458dc5e2b6bd1e8c/scipy-1.15.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:bae43364d600fdc3ac327db99659dcb79e6e7ecd279a75fe1266669d9a652828", size = 36545159 },
+    { url = "https://files.pythonhosted.org/packages/af/f5/ab3838e56fe5cc22383d6fcf2336e48c8fe33e944b9037fbf6cbdf5a11f8/scipy-1.15.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f031846580d9acccd0044efd1a90e6f4df3a6e12b4b6bd694a7bc03a89892b28", size = 39136566 },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/b3f566db71461cabd4b2d5b39bcc24a7e1c119535c8361f81426be39bb47/scipy-1.15.2-cp313-cp313t-win_amd64.whl", hash = "sha256:fe8a9eb875d430d81755472c5ba75e84acc980e4a8f6204d402849234d3017db", size = 40477705 },
+]
+
+[[package]]
+name = "semantic-kernel"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiortc" },
+    { name = "azure-identity" },
+    { name = "cloudevents" },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "nest-asyncio" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "openapi-core" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prance" },
+    { name = "pybars4" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "scipy" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/44/7e56342fe56632a5835adabfd35b1e89bff54b18fab208ceab715c220a8f/semantic_kernel-1.28.0.tar.gz", hash = "sha256:05567190e118b1121efb46d1b8e242f6fc593d7d60e406bc8fa719d80a30b218", size = 490829 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/d5/ef11ad435f3ad0c4ec344709b3e779166e973eadb67586c58bc6ab52cc71/semantic_kernel-1.28.0-py3-none-any.whl", hash = "sha256:84c899ad60fd3de1ad345f5f5cf3b6b18a94da1b397e01c96bc48a2fec7b8cee", size = 807149 },
 ]
 
 [[package]]
@@ -4366,6 +4849,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/af/d4502dc713b4ccea7175d764718d5183caf8d0867a4f0190d5d4a45cea49/werkzeug-3.1.1.tar.gz", hash = "sha256:8cd39dfbdfc1e051965f156163e2974e52c210f130810e9ad36858f0fd3edad4", size = 806453 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/ea/c67e1dee1ba208ed22c06d1d547ae5e293374bfc43e0eb0ef5e262b68561/werkzeug-3.1.1-py3-none-any.whl", hash = "sha256:a71124d1ef06008baafa3d266c02f56e1836a5984afd6dd6c9230669d60d9fb5", size = 224371 },
 ]
 
 [[package]]

--- a/samples/python/uv.lock
+++ b/samples/python/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -11,6 +10,7 @@ resolution-markers = [
 members = [
     "a2a-samples",
     "a2a-samples-image-gen",
+    "a2a-samples-mcp",
 ]
 
 [[package]]
@@ -85,6 +85,44 @@ requires-dist = [
     { name = "a2a-samples", editable = "." },
     { name = "crewai", extras = ["tools"], specifier = ">=0.95.0" },
     { name = "google-genai", specifier = ">=1.9.0" },
+]
+
+[[package]]
+name = "a2a-samples-mcp"
+version = "0.1.0"
+source = { virtual = "agents/ag2" }
+dependencies = [
+    { name = "a2a-samples" },
+    { name = "ag2", extra = ["mcp", "openai"] },
+    { name = "google-genai" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "a2a-samples", editable = "." },
+    { name = "ag2", specifier = ">=0.8.6" },
+    { name = "ag2", extras = ["mcp", "openai"], specifier = ">=0.8.6" },
+    { name = "google-genai", specifier = ">=1.10.0" },
+]
+
+[[package]]
+name = "ag2"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyautogen" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/71/e3dae00531eb31f5cf0b42b32035d3860f1b495e903bb652c22dc2e2326a/ag2-0.8.6.tar.gz", hash = "sha256:ad80461e3a007a881b2cd5164527eedb0008ca74d9a899b784179980bb0ee469", size = 42555 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/23/2be3bd07341e69b12c3e372ba4d325b584218fbd2a2b96f9382e9ef99d68/ag2-0.8.6-py3-none-any.whl", hash = "sha256:27aa657942efabebd29a9590da0bf177b46e41c1791308e6d09958dbbd463b63", size = 13572 },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "pyautogen", extra = ["mcp"] },
+]
+openai = [
+    { name = "pyautogen", extra = ["openai"] },
 ]
 
 [[package]]
@@ -249,6 +287,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/e1e5fdf1c1bb7e6e6
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/cc/a436f0fc2d04e57a0697e0f87a03b9eaed03ad043d2d5f887f8eebcec95f/asyncclick-8.1.8-py3-none-any.whl", hash = "sha256:eb1ccb44bc767f8f0695d592c7806fdf5bd575605b4ee246ffd5fadbcfdbd7c6", size = 99093 },
     { url = "https://files.pythonhosted.org/packages/92/c4/ae9e9d25522c6dc96ff167903880a0fe94d7bd31ed999198ee5017d977ed/asyncclick-8.1.8.0-py3-none-any.whl", hash = "sha256:be146a2d8075d4fe372ff4e877f23c8b5af269d16705c1948123b9415f6fd678", size = 99115 },
+]
+
+[[package]]
+name = "asyncer"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209 },
 ]
 
 [[package]]
@@ -765,6 +815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550 },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.9.0"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1262,9 +1321,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/b9/fae20a998946f811d81b14b4e2da41d0d7779c3e63dedf4538c16832fa56/google_genai-1.9.0.tar.gz", hash = "sha256:eda833dcef2e3b9a05bff96ff4e0066740988199bcee0b2480cfce9909b18a26", size = 151602 }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/224e2f70c835202042969685ee3da00a6475508d1b64f0f1e90144f96beb/google_genai-1.10.0.tar.gz", hash = "sha256:f59423e0f155dc66b7792c8a0e6724c75c72dc699d1eb7907d4d0006d4f6186f", size = 156355 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/12/3a5a11589a0b967b371c773d35cc54c75f2f44259d3d767b826d708b6377/google_genai-1.9.0-py3-none-any.whl", hash = "sha256:2140f72e6e5b89d8105fa70ae551c699b5e39492ca5f95053e1f7e99ecbdbd35", size = 149646 },
+    { url = "https://files.pythonhosted.org/packages/ba/a0/56839a2e202d79c773edd1c1db124da8eb2a7b657267a888080b678d0369/google_genai-1.10.0-py3-none-any.whl", hash = "sha256:41b105a2fcf8a027fc45cc16694cd559b8cd1272eab7345ad58cfa2c353bf34f", size = 154705 },
 ]
 
 [[package]]
@@ -2211,7 +2270,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2223,9 +2282,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c9/c55764824e893fdebe777ac7223200986a275c3191dba9169f8eb6d7c978/mcp-1.5.0.tar.gz", hash = "sha256:5b2766c05e68e01a2034875e250139839498c61792163a7b221fc170c12f5aa9", size = 159128 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077 },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/3ff566ecf322077d861f1a68a1ff025cad337417bd66ad22a7c6f7dfcfaf/mcp-1.5.0-py3-none-any.whl", hash = "sha256:51c3f35ce93cb702f7513c12406bbea9665ef75a08db909200b07da9db641527", size = 73734 },
 ]
 
 [[package]]
@@ -3127,6 +3186,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pyautogen"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "asyncer" },
+    { name = "diskcache" },
+    { name = "docker" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "termcolor" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e7/a004b399ee7fff59c4b36dd62c0a141e073f335dc78e7801c70fcce50238/pyautogen-0.8.6.tar.gz", hash = "sha256:6102b58965cc920a5ed1f550f3dffd27e86c2210ca48eef1c0b41452b9531c6c", size = 3186688 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/1cf6f4caaa3f9dc99fe20a76fa03386704b50ca0d2dc96c9c6b9056fc750/pyautogen-0.8.6-py3-none-any.whl", hash = "sha256:9c8eec9f310d1ad5bd7558d276e7fb1654eff4b0a67104321811a06b90759f7d", size = 734173 },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
+]
+openai = [
+    { name = "openai" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -3864,6 +3952,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b6/8e2aaa8aeb570b5cc955cd913b083d96c5447bbe27eaf330dfd7cc8e3329/termcolor-3.0.1.tar.gz", hash = "sha256:a6abd5c6e1284cea2934443ba806e70e5ec8fd2449021be55c280f8a3731b611", size = 12935 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/7e/a574ccd49ad07e8b117407bac361f1e096b01f1b620365daf60ff702c936/termcolor-3.0.1-py3-none-any.whl", hash = "sha256:da1ed4ec8a5dc5b2e17476d859febdb3cccb612be1c36e64511a6f2485c10c69", size = 7157 },
 ]
 
 [[package]]

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -534,6 +534,7 @@
           }
         },
         "required": [
+          "type",
           "data"
         ],
         "title": "DataPart",
@@ -624,6 +625,7 @@
           }
         },
         "required": [
+          "type",
           "file"
         ],
         "title": "FilePart",
@@ -827,7 +829,10 @@
           },
           "data": {
             "anyOf": [
-              {},
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
               {
                 "type": "null"
               }
@@ -867,7 +872,10 @@
           },
           "data": {
             "anyOf": [
-              {},
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
               {
                 "type": "null"
               }
@@ -907,7 +915,10 @@
           },
           "data": {
             "anyOf": [
-              {},
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
               {
                 "type": "null"
               }
@@ -947,7 +958,10 @@
           },
           "data": {
             "anyOf": [
-              {},
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
               {
                 "type": "null"
               }
@@ -975,7 +989,10 @@
           },
           "data": {
             "anyOf": [
-              {},
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
               {
                 "type": "null"
               }
@@ -1087,7 +1104,10 @@
           },
           "result": {
             "anyOf": [
-              {},
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
               {
                 "type": "null"
               }
@@ -1533,6 +1553,21 @@
             "default": null,
             "title": "Artifacts"
           },
+          "history": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/$defs/Message"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "History"
+          },
           "metadata": {
             "anyOf": [
               {
@@ -1666,7 +1701,7 @@
         "required": [
           "id"
         ],
-        "title": "TaskQueryParams",
+        "title": "TaskIdParams",
         "type": "object"
       },
       "TaskQueryParams": {
@@ -1941,6 +1976,7 @@
           }
         },
         "required": [
+          "type",
           "text"
         ],
         "title": "TextPart",


### PR DESCRIPTION
Includes the `samples/python/agents/ag2/` fully implemented example. Only stream supposed (`on_task_send_subscribe`).  Some dummy code for `on_task_send()` and `invoke()`. 

Includes updated upstream A2A, might want to sync again afterwards. 